### PR TITLE
Clarified import and FC usage in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Make sure that you have at least version 16.8 of `react` and `react-dom` install
 ### Usage
 With TypeScript
 ```typescript jsx
-export const ExampleComponent: React.FunctionComponent<{}> = () => {
+import { useHotkeys } from 'react-hotkeys-hook';
+
+export const ExampleComponent: React.FC = () => {
   const [count, setCount] = useState(0);
   useHotkeys('ctrl+k', () => setCount(prevCount => prevCount + 1));
 


### PR DESCRIPTION
A couple of things to note:
* You don't have to provide the `{}` type for react function components, as it defaults to nothing
* It's not clear whether `useHotkeys` is intended to be a default export or named, so I added it as named

Thanks for this package by the way. Super useful!