### PR TITLE
Directly use KeyHandler type from hotkeys-js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,13 @@
-import hotkeys, { HotkeysEvent } from "hotkeys-js";
+import hotkeys, { KeyHandler } from "hotkeys-js";
 import { useCallback, useEffect } from "react";
 
-type CallbackFn = (event: KeyboardEvent, handler: HotkeysEvent) => void;
 type Options = {
   filter?: typeof hotkeys.filter;
 };
 
 export function useHotkeys(
   keys: string,
-  callback: CallbackFn,
+  callback: KeyHandler,
   deps: any[] = [],
   options: Options = {}
 ) {


### PR DESCRIPTION
This PR uses the type declaration for `KeyHandler` directly from `hotkeys-js`, so the type is not duplicated here.

For background, I have a separate PR for `hotkeys-js` https://github.com/jaywcjlove/hotkeys/pull/164 that updates the `KeyHandler` return type.