### PR TITLE
fix(dependencies): move `np` to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     ]
   },
   "dependencies": {
-    "hotkeys-js": "3.8.1",
-    "np": "6.3.2"
+    "hotkeys-js": "3.8.1"
   },
   "devDependencies": {
     "@babel/core": "7.10.5",
@@ -80,6 +79,7 @@
     "emotion-theming": "10.0.27",
     "gatsby-plugin-emotion": "4.3.10",
     "jest": "26.1.0",
+    "np": "6.3.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-test-renderer": "16.13.1",


### PR DESCRIPTION
Package `np` is not used in the source code. Having `np` in `dependencies` means all projects that list `react-hotkeys-hook` in their dependencies will have their package manager install `np` and all it's crazy sprawling sub-dependencies.

Example: `dependabot` wants to upgrade just this package in a sample project, results in ~800 lines added to `yarn.lock`:

<img width="1003" alt="Screenshot 2020-07-29 02 45 47" src="https://user-images.githubusercontent.com/6012912/88785349-e8636c80-d145-11ea-9bc0-e844bbc6cdb1.png">
