### PR TITLE
[feature] added a new option flag to allow/prevent default behavior on filter failure, added documentation for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ section on the hotkeys documentation for more info.
 gets hit by the user. **Important:** Since version 1.5.0 this callback gets memoised inside the hook. So you don't have
 to do this anymore by yourself.
 - `options: Options = {}`
-  - * `filter: (event: KeyboardEvent): boolean` is used to filter if a callback gets triggered depending on the keyboard event.
+  - `filter: (event: KeyboardEvent): boolean` is used to filter if a callback gets triggered depending on the keyboard event.
     **Breaking Change in `3.0.0`!** Prior to version `3.0.0` the filter settings was one global setting that applied to every
     hook. Since `3.0.0` this behavior changed. The `filter` option is now locally scoped to each call of `useHotkeys`.
-  - * `enableOnTags: string[]` is used to enable listening to hotkeys in form fields. Available values are `INPUT`, `TEXTAREA` and `SELECT`.
+  - `filterPreventDefault: boolean` is used to prevent/allow the default browser behavior for the keystroke when the filter return false (default value: `true`)
+  - `enableOnTags: string[]` is used to enable listening to hotkeys in form fields. Available values are `INPUT`, `TEXTAREA` and `SELECT`.
   - `splitKey: string` is used to change the splitting character inside the keys argument. Default is `+`, but if you want
     to listen to the `+` character, you can set `splitKey` to i.e. `-` and listen for `ctrl-+`
   - `keyup: boolean` Determine if you want to listen on the keyup event

--- a/docs/useHotkeys.mdx
+++ b/docs/useHotkeys.mdx
@@ -71,6 +71,8 @@ for an overview.
 * `filter: (event: KeyboardEvent): boolean` is used to filter if a callback gets triggered depending on the keyboard event.
 **Breaking Change in `3.0.0`!** Prior to version `3.0.0` the filter settings was one global setting that applied to every
 hook. Since `3.0.0` this behavior changed. The `filter` option is now locally scoped to each call of `useHotkeys`.
+* `filterPreventDefault: boolean` is used to prevent/allow the default browser behavior for the keystroke when the filter 
+return false (default value: `true`)
 * `enableOnTags: string[]` is used to enable listening to hotkeys in form fields. Available values are `INPUT`, `TEXTAREA`
 and `SELECT`.
 * `splitKey: string` is used to change the splitting character inside the keys argument. Default is `+`, but if you want

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -19,6 +19,7 @@ const isKeyboardEventTriggeredByInput = (ev: KeyboardEvent) => {
 
 export type Options = {
   filter?: typeof hotkeys.filter;
+  filterPreventDefault?: boolean;
   enableOnTags?: AvailableTags[];
   splitKey?: string;
   scope?: string;
@@ -35,12 +36,12 @@ export function useHotkeys<T extends Element>(keys: string, callback: KeyHandler
     options = undefined;
   }
 
-  const { enableOnTags, filter, keyup, keydown } = options || {};
+  const { enableOnTags, filter, keyup, keydown, filterPreventDefault = true } = options || {};
   const ref = useRef<T | null>(null);
 
   const memoisedCallback = useCallback((keyboardEvent: KeyboardEvent, hotkeysEvent: HotkeysEvent) => {
     if (filter && !filter(keyboardEvent)) {
-      return false;
+      return !filterPreventDefault;
     }
 
     if (isKeyboardEventTriggeredByInput(keyboardEvent) && !tagFilter(keyboardEvent, enableOnTags)) {


### PR DESCRIPTION
Pull Request for a new proposed Option flag which will allow or prevent the default browser behavior when the defined filter fails.

**Motivation**

Currently if the filter fails, the default behavior for the browser is prevented.
This might be undesirable if we are using any input that it's not an `INPUT`, `TEXTAREA` or `SELECT` (which is the case of libraries like `react-contenteditable` [https://github.com/lovasoa/react-contenteditable#readme](https://github.com/lovasoa/react-contenteditable#readme))
For this situations we might want to create a filter that ignores hotkeys when they come from those div-inputs, but we still want the default behavior of the browser to take place (eg: writing)