### PR TITLE
Add enable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ to do this anymore by yourself.
     to listen to the `+` character, you can set `splitKey` to i.e. `-` and listen for `ctrl-+`
   - `keyup: boolean` Determine if you want to listen on the keyup event
   - `keydown: boolean` Determine if want to listen on the keydown event
+  - `enabled: boolean` is used to prevent installation of the hotkey when set to false (default value: `true`)
 - `deps: any[] = []`: The dependency array that gets appended to the memoisation of the callback. Here you define the inner
 dependencies of your callback. If for example your callback actions depend on a referentially unstable value or a value
 that will change over time, you should add this value to your deps array. Since most of the time your callback won't

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -18,6 +18,7 @@ const isKeyboardEventTriggeredByInput = (ev: KeyboardEvent) => {
 };
 
 export type Options = {
+  enabled?: boolean;
   filter?: typeof hotkeys.filter;
   filterPreventDefault?: boolean;
   enableOnTags?: AvailableTags[];
@@ -36,7 +37,7 @@ export function useHotkeys<T extends Element>(keys: string, callback: KeyHandler
     options = undefined;
   }
 
-  const { enableOnTags, filter, keyup, keydown, filterPreventDefault = true } = options || {};
+  const { enableOnTags, filter, keyup, keydown, filterPreventDefault = true, enabled = true } = options as Options || {};
   const ref = useRef<T | null>(null);
 
   const memoisedCallback = useCallback((keyboardEvent: KeyboardEvent, hotkeysEvent: HotkeysEvent) => {
@@ -57,6 +58,10 @@ export function useHotkeys<T extends Element>(keys: string, callback: KeyHandler
   }, deps ? [ref, enableOnTags, filter, ...deps] : [ref, enableOnTags, filter]);
 
   useEffect(() => {
+    if(!enabled) {
+      return
+    }
+
     if (keyup && keydown !== true) {
       (options as Options).keydown = false;
     }


### PR DESCRIPTION
Given the nature of hooks it can be awkward to skip them
programmatically if they don't support this option directly.

This PR addresses
https://github.com/JohannesKlauss/react-hotkeys-hook/issues/480

And adds an option to `enable` installation of the hook, this option
defaults to `true`.  When set to `false`, no hotkey is installed, this
avoids the issue where you try and do the same thing using a filter and
forget to set `filterPreventDefault` to `false`.

Note that this has only been tested in my consuming app since I can't
get the gatsby stuff working ATM.