### PR TITLE
Update when `callback` is changed

### DIFF
--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -68,7 +68,7 @@ export function useHotkeys<T extends Element>(keys: string, callback: KeyHandler
     }
 
     return false;
-  }, deps ? [ref, enableOnTags, filter, ...deps] : [ref, enableOnTags, filter]);
+  }, [ref, enableOnTags, filter, callback, ...(deps || [])]);
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
Currently the `hotkeys` callback isn't updated when the `callback`
paramater to `useHotkeys` is changed.

This can cause issues when the `callback` references state which gets
updated between the time the component is first rendered and the time
the hotkey is pressed.

Unfortunately I don't know how to add an automated test for this condition.

A manual test can be performed with:

```js
function TestComponent() {
  const [count, setCount] = React.useState(0)
  useHotkeys('x', () => alert(`Count: ${count}`))
  return <button onClick={() => setCount(count + 1)}>Increment count: {count}</button>
}
```

And notice that, if the "Increment count" button is pressed, then the `x` key is pressed, the alert will show `Count: 0`, instead of the current count.