### PR TITLE
doc: fix typo in usehotkeys options

### DIFF
--- a/documentation/docs/api/use-hotkeys.mdx
+++ b/documentation/docs/api/use-hotkeys.mdx
@@ -143,8 +143,8 @@ const options = {
   enableOnTags: [],
   enabled: true,
   splitKey: '+',
-  keyup: true,
-  keydown: false
+  keyup: undefined,
+  keydown: true
 };
 ```
 


### PR DESCRIPTION
Fix for the issue https://github.com/JohannesKlauss/react-hotkeys-hook/issues/672

Before:
![image](https://user-images.githubusercontent.com/52677246/151723475-3066e0dd-d4d3-4e78-ac2d-dbe09c1e1d2f.png)

After:
![image](https://user-images.githubusercontent.com/52677246/151723503-cca1cd2a-0e90-4790-b749-fec0d80b6488.png)

Please let me know if there is something wrong, thanks for reviewing!
