### PR TITLE
Add alwaysNotPreventDefault option in useHotkeys

### DIFF
--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -20,7 +20,7 @@ export type Options = {
   enabled?: boolean; // Main setting that determines if the hotkey is enabled or not. (Default: true)
   filter?: typeof hotkeys.filter; // A filter function returning whether the callback should get triggered or not. (Default: undefined)
   filterPreventDefault?: boolean; // Prevent default browser behavior if the filter function returns false. (Default: true)
-  alwaysNotPreventDefault?: boolean; // Callback function returns always true. (Default: undefined)
+  neverPreventDefault?: boolean; // Callback function returns always true. (Default: undefined)
   enableOnTags?: AvailableTags[]; // Enable hotkeys on a list of tags. (Default: [])
   enableOnContentEditable?: boolean; // Enable hotkeys on tags with contentEditable props. (Default: false)
   splitKey?: string; // Character to split keys in hotkeys combinations. (Default +)
@@ -44,7 +44,7 @@ export function useHotkeys<T extends Element>(keys: string, callback: KeyHandler
     keyup,
     keydown,
     filterPreventDefault = true,
-    alwaysNotPreventDefault,
+    neverPreventDefault,
     enabled = true,
     enableOnContentEditable = false,
   } = options as Options || {};
@@ -69,7 +69,7 @@ export function useHotkeys<T extends Element>(keys: string, callback: KeyHandler
       return true;
     }
 
-    if (alwaysNotPreventDefault) {
+    if (neverPreventDefault) {
       return true;
     }
 

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -20,6 +20,7 @@ export type Options = {
   enabled?: boolean; // Main setting that determines if the hotkey is enabled or not. (Default: true)
   filter?: typeof hotkeys.filter; // A filter function returning whether the callback should get triggered or not. (Default: undefined)
   filterPreventDefault?: boolean; // Prevent default browser behavior if the filter function returns false. (Default: true)
+  alwaysNotPreventDefault?: boolean; // Callback function returns always true. (Default: undefined)
   enableOnTags?: AvailableTags[]; // Enable hotkeys on a list of tags. (Default: [])
   enableOnContentEditable?: boolean; // Enable hotkeys on tags with contentEditable props. (Default: false)
   splitKey?: string; // Character to split keys in hotkeys combinations. (Default +)
@@ -43,6 +44,7 @@ export function useHotkeys<T extends Element>(keys: string, callback: KeyHandler
     keyup,
     keydown,
     filterPreventDefault = true,
+    alwaysNotPreventDefault,
     enabled = true,
     enableOnContentEditable = false,
   } = options as Options || {};
@@ -64,6 +66,10 @@ export function useHotkeys<T extends Element>(keys: string, callback: KeyHandler
 
     if (ref.current === null || document.activeElement === ref.current) {
       callback(keyboardEvent, hotkeysEvent);
+      return true;
+    }
+
+    if (alwaysNotPreventDefault) {
       return true;
     }
 


### PR DESCRIPTION
## 🏁 Outline

Added option of useHotkeys to return always true in hotkeys callback!!

## 📝 Description

When using `enter` key, if there is an anchor tag like [example](https://codesandbox.io/s/not-working-enter-isimqs?file=/src/App.tsx), pressing `enter` key while the anchor tag is in focus does not take the user to another link.

Because `hotkeys` callback return false stops the event and prevents default browser events.
https://github.com/jaywcjlove/hotkeys#defining-shortcuts

I would like to be able to move to another link by pressing `enter` key on focus with an anchor that does not have a `ref` passed.(browser default behavior)
