### PR TITLE
Fix stuck keys in the pressedDownKeys set

### DIFF
--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -28,7 +28,6 @@ export default function useHotkeys<T extends HTMLElement>(
   dependencies?: OptionsOrDependencyArray,
 ) {
   const ref = useRef<RefType<T>>(null)
-  const { current: pressedDownKeys } = useRef<Set<string>>(new Set())
 
   const _options: Options | undefined = !(options instanceof Array) ? (options as Options) : !(dependencies instanceof Array) ? (dependencies as Options) : undefined
   const _deps: DependencyList = options instanceof Array ? options : dependencies instanceof Array ? dependencies : []
@@ -40,6 +39,8 @@ export default function useHotkeys<T extends HTMLElement>(
   const proxy = useBoundHotkeysProxy()
 
   useSafeLayoutEffect(() => {
+    const pressedDownKeys = new Set<string>();
+
     if (memoisedOptions?.enabled === false || !isScopeActive(enabledScopes, memoisedOptions?.scopes)) {
       return
     }


### PR DESCRIPTION
Hello. After updating to version 4.0.4, I encountered strange behavior when, after pressing some keys, they began to seem to stick. During debugging, it turned out that the pressedDownKeys set is being replaced and in callbacks for processing keys (keydown and keyup) the set is no longer what you need. This problem can be solved by moving this set to the callback area - this is safer for memory and, in principle, more correct in terms of working with this variable (it is not used anywhere else, except for the useLayoutEffect).

Apparently, the bug is reproduced when the component is unmounted and the userlayouteffect destructor is called, but I could be wrong.

Unfortunately, I did not have time to collect the minimum code to reproduce the bug, because the required behavior is quite complicated.