### PR TITLE
Fix handling of browser autofill

### DIFF
--- a/src/isHotkeyPressed.ts
+++ b/src/isHotkeyPressed.ts
@@ -42,10 +42,20 @@ export function removeFromCurrentlyPressedKeys(key: string | string[]): void {
   if (typeof window !== 'undefined') {
     window.addEventListener('DOMContentLoaded', () => {
       document.addEventListener('keydown', e => {
+        if (e.key === undefined) {
+          // Synthetic event (e.g., Chrome autofill).  Ignore.
+          return
+        }
+
         pushToCurrentlyPressedKeys(e.key)
       })
 
       document.addEventListener('keyup', e => {
+        if (e.key === undefined) {
+          // Synthetic event (e.g., Chrome autofill).  Ignore.
+          return
+        }
+
         removeFromCurrentlyPressedKeys(e.key)
       })
     })

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -80,6 +80,11 @@ export default function useHotkeys<T extends HTMLElement>(
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === undefined) {
+        // Synthetic event (e.g., Chrome autofill).  Ignore.
+        return
+      }
+
       pressedDownKeys.add(event.key.toLowerCase())
 
       if ((memoisedOptions?.keydown === undefined && memoisedOptions?.keyup !== true) || memoisedOptions?.keydown) {
@@ -88,6 +93,11 @@ export default function useHotkeys<T extends HTMLElement>(
     }
 
     const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key === undefined) {
+        // Synthetic event (e.g., Chrome autofill).  Ignore.
+        return
+      }
+
       if (event.key.toLowerCase() !== 'meta') {
         pressedDownKeys.delete(event.key.toLowerCase())
       } else {


### PR DESCRIPTION
If Chrome autofills an input field, it simulates keyup and keydown events with no `key` defined.  Handle that case.

Fixes #836