### PR TITLE
Add support for backquote character

### DIFF
--- a/src/parseHotkeys.ts
+++ b/src/parseHotkeys.ts
@@ -9,6 +9,7 @@ const mappedKeys: Record<string, string> = {
   ',': 'comma',
   '-': 'slash',
   ' ': 'space',
+  '`': 'backquote',
   '#': 'backslash',
   '+': 'bracketright',
   'ShiftLeft': 'shift',


### PR DESCRIPTION
Adds the backquote character (``` ` ```) to `mappedKeys`

![backquote](https://user-images.githubusercontent.com/92991945/212394126-2fef17a3-54f9-47cd-be04-2854dbddaedd.png)
