### PR TITLE
Update docs with renamed prop enableOnFormTags

### DIFF
--- a/documentation/docs/api/use-hotkeys.mdx
+++ b/documentation/docs/api/use-hotkeys.mdx
@@ -210,10 +210,10 @@ useHotkeys('meta+s', someCallback, {
 });
 ```
 
-##### `enableOnTags`
+##### `enableOnFormTags`
 
 ```ts
-enableOnTags: string[] // default: undefined
+enableOnFormTags: string[] // default: undefined
 ```
 
 Normally we do not want a hotkey being triggered while a user types something into an input field. In some cases however


### PR DESCRIPTION
The property was renamed in v4. Hopefully this fixes that. 