### PR TITLE
Fix infinite loop

### DIFF
--- a/src/parseHotkeys.ts
+++ b/src/parseHotkeys.ts
@@ -36,12 +36,8 @@ export function isHotkeyModifier(key: string) {
   return reservedModifierKeywords.includes(key)
 }
 
-export function parseKeysHookInput(keys: Keys, splitKey: string = ','): string[] {
-  if (typeof keys === 'string') {
+export function parseKeysHookInput(keys: string, splitKey: string = ','): string[] {
     return keys.split(splitKey)
-  }
-
-  return keys
 }
 
 export function parseHotkey(hotkey: string, combinationKey: string = '+'): Hotkey {

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -32,6 +32,7 @@ export default function useHotkeys<T extends HTMLElement>(
   const hasTriggeredRef = useRef(false)
 
   const _options: Options | undefined = !(options instanceof Array) ? (options as Options) : !(dependencies instanceof Array) ? (dependencies as Options) : undefined
+  const _keys: string = keys instanceof Array ? keys.join(_options?.splitKey) : keys
   const _deps: DependencyList | undefined = options instanceof Array ? options : dependencies instanceof Array ? dependencies : undefined
 
   const memoisedCB = useCallback(callback, _deps ?? [])
@@ -70,7 +71,7 @@ export default function useHotkeys<T extends HTMLElement>(
         return
       }
 
-      parseKeysHookInput(keys, memoisedOptions?.splitKey).forEach((key) => {
+      parseKeysHookInput(_keys, memoisedOptions?.splitKey).forEach((key) => {
         const hotkey = parseHotkey(key, memoisedOptions?.combinationKey)
 
         if (isHotkeyMatchingKeyboardEvent(e, hotkey, memoisedOptions?.ignoreModifiers) || hotkey.keys?.includes('*')) {
@@ -130,7 +131,7 @@ export default function useHotkeys<T extends HTMLElement>(
     (ref.current || _options?.document || document).addEventListener('keydown', handleKeyDown)
 
     if (proxy) {
-      parseKeysHookInput(keys, memoisedOptions?.splitKey).forEach((key) => proxy.addHotkey(parseHotkey(key, memoisedOptions?.combinationKey)))
+      parseKeysHookInput(_keys, memoisedOptions?.splitKey).forEach((key) => proxy.addHotkey(parseHotkey(key, memoisedOptions?.combinationKey)))
     }
 
     return () => {
@@ -140,10 +141,10 @@ export default function useHotkeys<T extends HTMLElement>(
       (ref.current || _options?.document || document).removeEventListener('keydown', handleKeyDown)
 
       if (proxy) {
-        parseKeysHookInput(keys, memoisedOptions?.splitKey).forEach((key) => proxy.removeHotkey(parseHotkey(key, memoisedOptions?.combinationKey)))
+        parseKeysHookInput(_keys, memoisedOptions?.splitKey).forEach((key) => proxy.removeHotkey(parseHotkey(key, memoisedOptions?.combinationKey)))
       }
     }
-  }, [JSON.stringify(keys), memoisedOptions, enabledScopes])
+  }, [_keys, memoisedOptions, enabledScopes])
 
   return ref
 }

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -143,7 +143,7 @@ export default function useHotkeys<T extends HTMLElement>(
         parseKeysHookInput(keys, memoisedOptions?.splitKey).forEach((key) => proxy.removeHotkey(parseHotkey(key, memoisedOptions?.combinationKey)))
       }
     }
-  }, [keys, memoisedOptions, enabledScopes])
+  }, [JSON.stringify(keys), memoisedOptions, enabledScopes])
 
   return ref
 }

--- a/tests/HotkeysProvider.test.tsx
+++ b/tests/HotkeysProvider.test.tsx
@@ -204,3 +204,20 @@ test('should update bound hotkeys when useHotkeys changes its scopes', () => {
 
   expect(result.current.hotkeys).toHaveLength(0)
 })
+
+test('should return bound hotkeys when defined as a string array', () => {
+  const useIntegratedHotkeys = () => {
+    useHotkeys(['a+c', 'b'], () => null, { scopes: ['foo'] })
+
+    return useHotkeysContext()
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider initiallyActiveScopes={['foo']}>{children}</HotkeysProvider>
+  )
+  const { result } = renderHook(useIntegratedHotkeys, {
+    wrapper,
+  })
+  expect(result.current.hotkeys[0].keys).toEqual(['a', 'c'])
+  expect(result.current.hotkeys[1].keys).toEqual(['b'])
+})


### PR DESCRIPTION
https://github.com/JohannesKlauss/react-hotkeys-hook/issues/944

This fixes an infinite loop that is caused by an array dependency in a `useEffect`. I simply serialize the array dependency in question only because using a ref or memoizing the `keys` prop was causing a test failure in `tests/useHotkeys.test.tsx L#274`.