### PR TITLE
Fix typo in documentation for advanced usage

### DIFF
--- a/documentation/docs/documentation/advanced-usage.mdx
+++ b/documentation/docs/documentation/advanced-usage.mdx
@@ -16,7 +16,7 @@ To avoid this confusion, we can use the typescript types provided by the `ts-key
 You add the library to your project by running:
 
 ```bash
-npm install ts-key-now
+npm install ts-key-enum
 ```
 
 Then you can import the types and use them in your code:


### PR DESCRIPTION
the right package name should be `ts-key-enum` instead of `ts-key-now`