### PR TITLE
Feat: Expose descriptions for currently-bound hotkeys.

### DIFF
--- a/src/parseHotkeys.ts
+++ b/src/parseHotkeys.ts
@@ -1,4 +1,4 @@
-import { Hotkey, KeyboardModifiers, Keys } from './types'
+import { Hotkey, KeyboardModifiers, Keys, Options } from './types'
 
 const reservedModifierKeywords = ['shift', 'alt', 'meta', 'mod', 'ctrl']
 
@@ -43,7 +43,7 @@ export function parseKeysHookInput(keys: Keys, splitKey = ','): string[] {
   return keys
 }
 
-export function parseHotkey(hotkey: string, combinationKey = '+'): Hotkey {
+export function parseHotkey(hotkey: string, combinationKey = '+', description?: string): Hotkey {
   const keys = hotkey
     .toLocaleLowerCase()
     .split(combinationKey)
@@ -62,5 +62,6 @@ export function parseHotkey(hotkey: string, combinationKey = '+'): Hotkey {
   return {
     ...modifiers,
     keys: singleCharKeys,
+    description,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export type KeyboardModifiers = {
 export type Hotkey = KeyboardModifiers & {
   keys?: string[]
   scopes?: Scopes
+  description?: string
 }
 
 export type HotkeysEvent = Hotkey

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -143,7 +143,7 @@ export default function useHotkeys<T extends HTMLElement>(
 
     if (proxy) {
       parseKeysHookInput(_keys, memoisedOptions?.splitKey).forEach((key) =>
-        proxy.addHotkey(parseHotkey(key, memoisedOptions?.combinationKey))
+        proxy.addHotkey(parseHotkey(key, memoisedOptions?.combinationKey, memoisedOptions?.description))
       )
     }
 
@@ -155,7 +155,7 @@ export default function useHotkeys<T extends HTMLElement>(
 
       if (proxy) {
         parseKeysHookInput(_keys, memoisedOptions?.splitKey).forEach((key) =>
-          proxy.removeHotkey(parseHotkey(key, memoisedOptions?.combinationKey))
+          proxy.removeHotkey(parseHotkey(key, memoisedOptions?.combinationKey, memoisedOptions?.description))
         )
       }
     }

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -142,7 +142,7 @@ export default function useHotkeys<T extends HTMLElement>(
 
     if (proxy) {
       parseKeysHookInput(keys, memoisedOptions?.splitKey).forEach((key) =>
-        proxy.addHotkey(parseHotkey(key, memoisedOptions?.combinationKey))
+        proxy.addHotkey(parseHotkey(key, memoisedOptions?.combinationKey, memoisedOptions?.description))
       )
     }
 
@@ -154,7 +154,7 @@ export default function useHotkeys<T extends HTMLElement>(
 
       if (proxy) {
         parseKeysHookInput(keys, memoisedOptions?.splitKey).forEach((key) =>
-          proxy.removeHotkey(parseHotkey(key, memoisedOptions?.combinationKey))
+          proxy.removeHotkey(parseHotkey(key, memoisedOptions?.combinationKey, memoisedOptions?.description))
         )
       }
     }

--- a/tests/HotkeysProvider.test.tsx
+++ b/tests/HotkeysProvider.test.tsx
@@ -175,6 +175,40 @@ test('should return all bound hotkeys', () => {
   expect(result.current.hotkeys).toHaveLength(1)
 })
 
+test('should return descriptions for bound hotkeys', () => {
+  const useIntegratedHotkeys = () => {
+    useHotkeys('a', () => null, { scopes: ['foo'], description: 'bar' })
+
+    return useHotkeysContext()
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider initiallyActiveScopes={['foo']}>{children}</HotkeysProvider>
+  )
+  const { result } = renderHook(useIntegratedHotkeys, {
+    wrapper,
+  })
+
+  expect(result.current.hotkeys[0].description).toEqual('bar')
+})
+
+test('should return descriptions for bound hotkeys', () => {
+  const useIntegratedHotkeys = () => {
+    useHotkeys('a', () => null, { scopes: ['foo'], description: 'bar' })
+
+    return useHotkeysContext()
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider initiallyActiveScopes={['foo']}>{children}</HotkeysProvider>
+  )
+  const { result } = renderHook(useIntegratedHotkeys, {
+    wrapper,
+  })
+
+  expect(result.current.hotkeys[0].description).toEqual('bar')
+})
+
 test('should update bound hotkeys when useHotkeys changes its scopes', () => {
   const useIntegratedHotkeys = (scopes: string[]) => {
     useHotkeys('a', () => null, { scopes })

--- a/tests/HotkeysProvider.test.tsx
+++ b/tests/HotkeysProvider.test.tsx
@@ -8,7 +8,7 @@ test('should render children', () => {
   const { getByText } = render(
     <HotkeysProvider>
       <div>Hello</div>
-    </HotkeysProvider>,
+    </HotkeysProvider>
   )
 
   expect(getByText('Hello')).toBeInTheDocument()
@@ -23,8 +23,9 @@ test('should default to wildcard scope', () => {
 })
 
 test('should default to wildcard scope if empty array is provided as initialActiveScopes', () => {
-  const wrapper = ({ children }: { children: ReactNode }) => <HotkeysProvider
-    initiallyActiveScopes={[]}>{children}</HotkeysProvider>
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider initiallyActiveScopes={[]}>{children}</HotkeysProvider>
+  )
   const { result } = renderHook(() => useHotkeysContext(), {
     wrapper,
   })
@@ -150,8 +151,9 @@ test('should keep wildcard scope active when all is the only active scope and ge
 })
 
 test('should return initially set scopes', () => {
-  const wrapper = ({ children }: { children: ReactNode }) => <HotkeysProvider
-    initiallyActiveScopes={['foo', 'bar']}>{children}</HotkeysProvider>
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider initiallyActiveScopes={['foo', 'bar']}>{children}</HotkeysProvider>
+  )
   const { result } = renderHook(() => useHotkeysContext(), {
     wrapper,
   })
@@ -166,22 +168,6 @@ test('should return all bound hotkeys', () => {
     return useHotkeysContext()
   }
 
-  const wrapper = ({ children }: { children: ReactNode }) => <HotkeysProvider
-    initiallyActiveScopes={['foo']}>{children}</HotkeysProvider>
-  const { result } = renderHook(useIntegratedHotkeys, {
-    wrapper,
-  })
-
-  expect(result.current.hotkeys).toHaveLength(1)
-})
-
-test('should return descriptions for bound hotkeys', () => {
-  const useIntegratedHotkeys = () => {
-    useHotkeys('a', () => null, { scopes: ['foo'], description: 'bar' })
-
-    return useHotkeysContext()
-  }
-
   const wrapper = ({ children }: { children: ReactNode }) => (
     <HotkeysProvider initiallyActiveScopes={['foo']}>{children}</HotkeysProvider>
   )
@@ -189,7 +175,7 @@ test('should return descriptions for bound hotkeys', () => {
     wrapper,
   })
 
-  expect(result.current.hotkeys[0].description).toEqual('bar')
+  expect(result.current.hotkeys).toHaveLength(1)
 })
 
 test('should return descriptions for bound hotkeys', () => {
@@ -217,20 +203,19 @@ test('should update bound hotkeys when useHotkeys changes its scopes', () => {
   }
 
   const wrapper = ({ children }: { children: ReactNode }) => {
-    return (
-      <HotkeysProvider initiallyActiveScopes={['foo']}>
-        {children}
-      </HotkeysProvider>
-    )
+    return <HotkeysProvider initiallyActiveScopes={['foo']}>{children}</HotkeysProvider>
   }
 
-  const { result, rerender } = renderHook<{ scopes: string[] }, HotkeysContextType>(({ scopes }) => useIntegratedHotkeys(scopes), {
-    // @ts-ignore
-    wrapper,
-    initialProps: {
-      scopes: ['foo'],
-    },
-  })
+  const { result, rerender } = renderHook<{ scopes: string[] }, HotkeysContextType>(
+    ({ scopes }) => useIntegratedHotkeys(scopes),
+    {
+      // @ts-ignore
+      wrapper,
+      initialProps: {
+        scopes: ['foo'],
+      },
+    }
+  )
 
   expect(result.current.hotkeys).toHaveLength(1)
 
@@ -254,4 +239,21 @@ test('should return bound hotkeys when defined as a string array', () => {
   })
   expect(result.current.hotkeys[0].keys).toEqual(['a', 'c'])
   expect(result.current.hotkeys[1].keys).toEqual(['b'])
+})
+
+test('should return descriptions for bound hotkeys', () => {
+  const useIntegratedHotkeys = () => {
+    useHotkeys('a', () => null, { scopes: ['foo'], description: 'bar' })
+
+    return useHotkeysContext()
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider initiallyActiveScopes={['foo']}>{children}</HotkeysProvider>
+  )
+  const { result } = renderHook(useIntegratedHotkeys, {
+    wrapper,
+  })
+
+  expect(result.current.hotkeys[0].description).toEqual('bar')
 })

--- a/tests/HotkeysProvider.test.tsx
+++ b/tests/HotkeysProvider.test.tsx
@@ -178,23 +178,6 @@ test('should return all bound hotkeys', () => {
   expect(result.current.hotkeys).toHaveLength(1)
 })
 
-test('should return descriptions for bound hotkeys', () => {
-  const useIntegratedHotkeys = () => {
-    useHotkeys('a', () => null, { scopes: ['foo'], description: 'bar' })
-
-    return useHotkeysContext()
-  }
-
-  const wrapper = ({ children }: { children: ReactNode }) => (
-    <HotkeysProvider initiallyActiveScopes={['foo']}>{children}</HotkeysProvider>
-  )
-  const { result } = renderHook(useIntegratedHotkeys, {
-    wrapper,
-  })
-
-  expect(result.current.hotkeys[0].description).toEqual('bar')
-})
-
 test('should update bound hotkeys when useHotkeys changes its scopes', () => {
   const useIntegratedHotkeys = (scopes: string[]) => {
     useHotkeys('a', () => null, { scopes })


### PR DESCRIPTION
This PR exposes the `description` option in the `hotkeys` array returned by `useHotkeysContext()`.  Helpful if you want to display a list of currently-active hotkeys to the user.