### PR TITLE
Tiny fix: correct name of enableScope/disableScope in README and test description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ export const ExampleComponent = () => {
 
 #### Changing a scope's active state
 
-You can change the active state of a scope using the `deactivateScope`, `activateScope` and `toggleScope` functions
+You can change the active state of a scope using the `disableScope`, `enableScope` and `toggleScope` functions
 returned by the `useHotkeysContext()` hook. Note that you have to have your app wrapped in a `<HotkeysProvider>` component.
 
 ```jsx harmony

--- a/tests/HotkeysProvider.test.tsx
+++ b/tests/HotkeysProvider.test.tsx
@@ -43,7 +43,7 @@ test('should return active scopes and scope modifying functions', () => {
   expect(result.current.toggleScope).toBeInstanceOf(Function)
 })
 
-test('should activate scope by calling activateScope', () => {
+test('should activate scope by calling enableScope', () => {
   const { result } = renderHook(() => useHotkeysContext(), {
     wrapper: HotkeysProvider,
   })
@@ -91,7 +91,7 @@ test('should return multiple scopes if different scopes are activated', () => {
   expect(result.current.enabledScopes).toEqual(['foo', 'bar'])
 })
 
-test('should deactivate scope by calling deactivateScope', () => {
+test('should deactivate scope by calling disableScope', () => {
   const { result } = renderHook(() => useHotkeysContext(), {
     wrapper: HotkeysProvider,
   })


### PR DESCRIPTION
Just a minor typo fix. Thanks for the library!