### PR TITLE
Fix repository link

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "react-hotkeys-hook",
   "description": "React hook for handling keyboard shortcuts",
   "version": "4.4.1",
-  "repository": "https://github.com/JohannesKlauss/react-keymap-hook.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JohannesKlauss/react-keymap-hook.git"
+  },
   "homepage": "https://johannesklauss.github.io/react-hotkeys-hook/",
   "author": "Johannes Klauss",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-hotkeys-hook",
   "description": "React hook for handling keyboard shortcuts",
   "version": "4.4.1",
-  "repository": "https://JohannesKlauss@github.com/JohannesKlauss/react-keymap-hook.git",
+  "repository": "https://github.com/JohannesKlauss/react-keymap-hook.git",
   "homepage": "https://johannesklauss.github.io/react-hotkeys-hook/",
   "author": "Johannes Klauss",
   "main": "dist/index.js",


### PR DESCRIPTION
I was exploring hotkey libraries and came across `react-hotkeys-hook`. Great work! 👏  When [comparing the alternatives using NPM trends](https://npmtrends.com/hotkeys-js-vs-keymaster-vs-react-hotkeys-vs-react-hotkeys-hook-vs-react-keyboard-vs-react-keys-vs-react-shortcut-key-vs-react-shortcuts), I noticed that your lib’s GitHub link 🖍️ was missing:

![Screenshot 2023-12-07 at 15 02 04](https://github.com/JohannesKlauss/react-hotkeys-hook/assets/608862/7e8d23a8-8d5a-4372-8b03-d5ca703df8d0)

I believe that it’s because of a username in the URL, which this PR removes.

Keeping `.git` in the end is fine, AFAIU ([example](https://unpkg.com/browse/hotkeys-js@3.12.2/package.json#L30)). I guess we could keep a short notation (just a string) but I switched to an object to match [docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository).

Interestingly, npmjs.com recognises the URL correctly and removes the username. But because it is unconventional, some tools like NPM trends may struggle with this metadata format.

![Screenshot 2023-12-07 at 15 17 46](https://github.com/JohannesKlauss/react-hotkeys-hook/assets/608862/21a22e76-193e-4db1-a4c3-0ac3074be30f)

A new version of the package needs to be published for the metadata to get fixed.