### PR TITLE
fix: focus trap did not work for shadow root

### DIFF
--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -70,14 +70,16 @@ export default function useHotkeys<T extends HTMLElement>(
 
       // TODO: SINCE THE EVENT IS NOW ATTACHED TO THE REF, THE ACTIVE ELEMENT CAN NEVER BE INSIDE THE REF. THE HOTKEY ONLY TRIGGERS IF THE
       // REF IS THE ACTIVE ELEMENT. THIS IS A PROBLEM SINCE FOCUSED SUB COMPONENTS WON'T TRIGGER THE HOTKEY.
-      if (
-        ref.current !== null &&
-        document.activeElement !== ref.current &&
-        !ref.current.contains(document.activeElement)
-      ) {
-        stopPropagation(e)
-
-        return
+      if (ref.current !== null) {
+        const rootNode = ref.current.getRootNode()
+        if (
+          (rootNode instanceof Document || rootNode instanceof ShadowRoot) &&
+          rootNode.activeElement !== ref.current &&
+          !ref.current.contains(rootNode.activeElement)
+        ) {
+          stopPropagation(e)
+          return
+        }
       }
 
       if ((e.target as HTMLElement)?.isContentEditable && !memoisedOptions?.enableOnContentEditable) {


### PR DESCRIPTION
### Problem

The intended element that receives the focus might be inside a shadow root. In such case the correct check for active element should be against the closest `ShadowRoot.activeElement`.

Example sandbox: https://codesandbox.io/p/sandbox/react-hotkeys-hook-shadow-root-focus-trap-cpp7kj

### Solution

Instead of assuming document.activeElement, find the closest root node from ref.current first.