### PR TITLE
Fix default value for mapKey

### DIFF
--- a/src/parseHotkeys.ts
+++ b/src/parseHotkeys.ts
@@ -25,7 +25,7 @@ const mappedKeys: Record<string, string> = {
 }
 
 export function mapKey(key: string): string {
-  return (mappedKeys[key] || key)
+  return (mappedKeys[key] || key || '')
     .trim()
     .toLowerCase()
     .replace(/key|digit|numpad|arrow/, '')

--- a/src/parseHotkeys.ts
+++ b/src/parseHotkeys.ts
@@ -24,7 +24,7 @@ const mappedKeys: Record<string, string> = {
   ControlRight: 'ctrl',
 }
 
-export function mapKey(key: string): string {
+export function mapKey(key?: string): string {
   return (mappedKeys[key] || key || '')
     .trim()
     .toLowerCase()


### PR DESCRIPTION
I ran into an issue using this library in IE11, luckily enough it was a very simple fix.

For some reason, I get `undefined` values in the `mapKey` functions and get the error:

```txt
Unable to get property 'trim' of undefined or null reference
```

So this fix just sets a default value for the `mapKey` function to ensure it never hits that error.


Normally, I'd just patch this on my own (no need for every package to support IE11 like I have to), but it was such a simple guard that I figured someone else would run into it eventually and it doesn't bloat anything.

I appreciate your work here, and hope you have a nice day!
