### PR TITLE
fix: example code in use-hotkeys docs

### DIFF
--- a/documentation/docs/api/use-hotkeys.mdx
+++ b/documentation/docs/api/use-hotkeys.mdx
@@ -85,7 +85,7 @@ useHotkeys(['ctrl+a', 'shift+b', 'r', 'f'], (_, handler) => {
   switch (handler.keys.join('')) {
     case 'a': alert('You pressed ctrl+a!');
       break;
-    case 'b': alert('You pressed ctrl+b!');
+    case 'b': alert('You pressed shift+b!');
       break;
     case 'r': alert('You pressed r!');
       break;

--- a/documentation/docs/api/use-hotkeys.mdx
+++ b/documentation/docs/api/use-hotkeys.mdx
@@ -66,7 +66,7 @@ useHotkeys('ctrl+a, shift+b, r, f', (_, handler) => {
   switch (handler.keys.join('')) {
     case 'a': alert('You pressed ctrl+a!');
       break;
-    case 'b': alert('You pressed ctrl+b!');
+    case 'b': alert('You pressed shift+b!');
       break;
     case 'r': alert('You pressed r!');
       break;


### PR DESCRIPTION
There was a very small modification inside the use Hotkeys docs.
I think it would have been hard to find, but I found it while checking the example and post a PR.