### PR TITLE
Fix: example code in is-hotkey-pressed docs

### DIFF
--- a/documentation/src/theme/ReactLiveScope/index.ts
+++ b/documentation/src/theme/ReactLiveScope/index.ts
@@ -1,9 +1,10 @@
 import React from 'react';
-import { useHotkeys, useRecordHotkeys } from 'react-hotkeys-hook'
+import { isHotkeyPressed, useHotkeys, useRecordHotkeys } from 'react-hotkeys-hook'
 // Add react-live imports you need here
 const ReactLiveScope = {
   React,
   ...React,
+  isHotkeyPressed,
   useHotkeys,
   useRecordHotkeys,
 };


### PR DESCRIPTION
Add react-live imports definition for is-hotkey-pressed docs.
closes https://github.com/JohannesKlauss/react-hotkeys-hook/issues/1046

Fix count change on button click in LIVE EDITOR.
![image](https://github.com/JohannesKlauss/react-hotkeys-hook/assets/7314660/9acc68a3-8a53-4578-b57b-a4b0db96ff39)
