### PR TITLE
Update advanced-usage.mdx

### DIFF
--- a/documentation/docs/documentation/advanced-usage.mdx
+++ b/documentation/docs/documentation/advanced-usage.mdx
@@ -11,7 +11,7 @@ This section described advanced functionalities of the hook.
 
 ## Using typescript types to reference key names
 Sometimes we might get confused if we need to listen to `ArrowLeft` or `LeftArrow` to listen to the left arrow key.
-To avoid this confusion, we can use the typescript types provided by the `ts-key-now` library.
+To avoid this confusion, we can use the typescript types provided by the `ts-key-enum` library.
 
 You add the library to your project by running:
 


### PR DESCRIPTION
Fix typo in docs.

package `ts-key-now` does not exist in npm registry.

`ts-key-enum` is a correct package name.
