### PR TITLE
feature(addEventListener): passthrough event listener options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,15 @@ export type Scopes = string | readonly string[]
 
 export type RefType<T> = T | null
 
+export type EventListenerOptions =
+  | {
+      capture?: boolean
+      once?: boolean
+      passive?: boolean
+      signal?: AbortSignal
+    }
+  | boolean // useCapture
+
 export type KeyboardModifiers = {
   alt?: boolean
   ctrl?: boolean
@@ -41,6 +50,7 @@ export type Options = {
   description?: string // Use this option to describe what the hotkey does. (Default: undefined)
   document?: Document // Listen to events on the document instead of the window. (Default: false)
   ignoreModifiers?: boolean // Ignore modifiers when matching hotkeys. (Default: false)
+  eventListenerOptions?: EventListenerOptions // Passthrough event listener options. (Default: false)
 }
 
 export type OptionsOrDependencyArray = Options | DependencyList

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -155,9 +155,9 @@ export default function useHotkeys<T extends HTMLElement>(
 
     return () => {
       // @ts-ignore
-      domNode.removeEventListener('keyup', handleKeyUp, _options.eventListenerOptions)
+      domNode.removeEventListener('keyup', handleKeyUp, _options?.eventListenerOptions)
       // @ts-ignore
-      domNode.removeEventListener('keydown', handleKeyDown, _options.eventListenerOptions)
+      domNode.removeEventListener('keydown', handleKeyDown, _options?.eventListenerOptions)
 
       if (proxy) {
         parseKeysHookInput(_keys, memoisedOptions?.splitKey).forEach((key) =>

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -143,9 +143,9 @@ export default function useHotkeys<T extends HTMLElement>(
     const domNode = ref || _options?.document || document
 
     // @ts-ignore
-    domNode.addEventListener('keyup', handleKeyUp)
+    domNode.addEventListener('keyup', handleKeyUp, _options?.eventListenerOptions)
     // @ts-ignore
-    domNode.addEventListener('keydown', handleKeyDown)
+    domNode.addEventListener('keydown', handleKeyDown, _options?.eventListenerOptions)
 
     if (proxy) {
       parseKeysHookInput(_keys, memoisedOptions?.splitKey).forEach((key) =>
@@ -155,9 +155,9 @@ export default function useHotkeys<T extends HTMLElement>(
 
     return () => {
       // @ts-ignore
-      domNode.removeEventListener('keyup', handleKeyUp)
+      domNode.removeEventListener('keyup', handleKeyUp, _options.eventListenerOptions)
       // @ts-ignore
-      domNode.removeEventListener('keydown', handleKeyDown)
+      domNode.removeEventListener('keydown', handleKeyDown, _options.eventListenerOptions)
 
       if (proxy) {
         parseKeysHookInput(_keys, memoisedOptions?.splitKey).forEach((key) =>

--- a/tests/useHotkeys.test.tsx
+++ b/tests/useHotkeys.test.tsx
@@ -496,29 +496,29 @@ test('should be disabled on form tags inside custom elements by default', async 
   const callback = jest.fn()
 
   customElements.define(
-    "custom-input",
+    'custom-input',
     class extends HTMLElement {
       constructor() {
-        super();
+        super()
 
-        const inputEle = document.createElement("input");
-        inputEle.setAttribute("type", "text");
-        inputEle.setAttribute("data-testid", "input");
+        const inputEle = document.createElement('input')
+        inputEle.setAttribute('type', 'text')
+        inputEle.setAttribute('data-testid', 'input')
 
         const shadowRoot = this.attachShadow({
-          mode: "open"
-        });
+          mode: 'open',
+        })
 
-        shadowRoot.appendChild(inputEle);
+        shadowRoot.appendChild(inputEle)
       }
-    },
-  );
+    }
+  )
 
   const Component = ({ cb }: { cb: HotkeyCallback }) => {
     useHotkeys<HTMLDivElement>('a', cb)
 
     // @ts-ignore
-    return <custom-input data-testid={'form-tag'}/>
+    return <custom-input data-testid={'form-tag'} />
   }
 
   const { getByTestId } = render(<Component cb={callback} />)
@@ -1412,4 +1412,34 @@ test('Should listen to special chars with modifiers', async () => {
   await user.keyboard(`{Shift>}-{/Shift}`)
 
   expect(callback).toHaveBeenCalledTimes(1)
+})
+
+test('Should remove listener on AbortSignal', async () => {
+  const abortController = new AbortController()
+  const { signal } = abortController
+
+  function Fixture() {
+    const [count, setCount] = useState(0)
+
+    const incrementCount = useCallback(() => {
+      setCount(count + 1)
+    }, [count])
+
+    useHotkeys('esc', incrementCount, { eventListenerOptions: { signal } })
+
+    return <div>{count}</div>
+  }
+
+  const user = userEvent.setup()
+
+  const { getByText } = render(<Fixture />)
+
+  expect(getByText('0')).not.toBeNull()
+
+  await user.keyboard('{Escape}')
+  await user.keyboard('{Escape}')
+  abortController.abort()
+  await user.keyboard('{Escape}')
+
+  expect(getByText('2')).not.toBeNull()
 })


### PR DESCRIPTION
Proposal to passthrough `useCapture` or `options` to `addEventListener` and `removeEventListener`.

My team has found it necessary to specify `options.capture` and/or `options.signal` in several of our hot keys. This PR adds an additional `eventListenerOptions?: EventListenerOptions` to the `Options` that can be passed through to the `addEventListener` and `removeEventListener` calls to allow consumers to specify those options when necessary.