### PR TITLE
Remove explicit 'null' type from useRef uses.

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/types.ts
+++ b/packages/react-hotkeys-hook/src/lib/types.ts
@@ -4,8 +4,6 @@ export type FormTags = 'input' | 'textarea' | 'select' | 'INPUT' | 'TEXTAREA' | 
 export type Keys = string | readonly string[]
 export type Scopes = string | readonly string[]
 
-export type RefType<T> = T | null
-
 export type EventListenerOptions =
   | {
   capture?: boolean

--- a/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
@@ -1,4 +1,4 @@
-import { HotkeyCallback, Keys, Options, OptionsOrDependencyArray, RefType } from './types'
+import { HotkeyCallback, Keys, Options, OptionsOrDependencyArray } from './types'
 import { DependencyList, useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import { mapCode, parseHotkey, parseKeysHookInput } from './parseHotkeys'
 import {
@@ -28,7 +28,7 @@ export default function useHotkeys<T extends HTMLElement>(
   options?: OptionsOrDependencyArray,
   dependencies?: OptionsOrDependencyArray
 ) {
-  const ref = useRef<RefType<T>>(null)
+  const ref = useRef<T>(null)
   const hasTriggeredRef = useRef(false)
 
   const _options: Options | undefined = !(options instanceof Array)


### PR DESCRIPTION
Fixes support for react 18. 

Resolves #1238. Sample CI run: https://github.com/dbowring/react-hotkeys-hook/actions/runs/14903894212/job/41861786048?pr=2