### PR TITLE
Fix missing hotkey prop

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/parseHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/parseHotkeys.ts
@@ -43,6 +43,8 @@ export function parseHotkey(
   let keys: string[] = []
   let isSequence = false
 
+  // hotkey might contain a leading space from eg. `ctrl+a, shift+a`
+  hotkey = hotkey.trim()
   if (hotkey.includes(sequenceSplitKey)) {
     isSequence = true
     keys = hotkey
@@ -72,5 +74,6 @@ export function parseHotkey(
     keys: singleCharKeys,
     description,
     isSequence,
+    hotkey,
   }
 }

--- a/packages/react-hotkeys-hook/src/lib/types.ts
+++ b/packages/react-hotkeys-hook/src/lib/types.ts
@@ -27,6 +27,7 @@ export type Hotkey = KeyboardModifiers & {
   scopes?: Scopes
   description?: string
   isSequence?: boolean
+  hotkey: string
 }
 
 export type HotkeysEvent = Hotkey

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -369,6 +369,19 @@ test('should listen to multiple combinations with modifiers', async () => {
   await user.keyboard('{Alt>}B{/Alt}')
 
   expect(callback).toHaveBeenCalledTimes(2)
+
+  // Assert the leading space from alt+b is dropped
+  expect(callback).toHaveBeenCalledWith(expect.any(KeyboardEvent), {
+    keys: ['b'],
+    shift: false,
+    ctrl: false,
+    alt: true,
+    meta: false,
+    mod: false,
+    useKey: false,
+    isSequence: false,
+    hotkey: 'alt+b',
+  })
 })
 
 test('should listen to sequences', async () => {
@@ -1096,6 +1109,7 @@ test('should pass keyboard event and hotkey object to callback', async () => {
     mod: false,
     useKey: false,
     isSequence: false,
+    hotkey: 'a',
   })
 })
 
@@ -1117,6 +1131,7 @@ test('should set shift to true in hotkey object if listening to shift', async ()
     mod: false,
     useKey: false,
     isSequence: false,
+    hotkey: 'shift+a',
   })
 })
 
@@ -1138,6 +1153,7 @@ test('should set ctrl to true in hotkey object if listening to ctrl', async () =
     mod: false,
     useKey: false,
     isSequence: false,
+    hotkey: 'ctrl+a',
   })
 })
 
@@ -1159,6 +1175,7 @@ test('should set alt to true in hotkey object if listening to alt', async () => 
     mod: false,
     useKey: false,
     isSequence: false,
+    hotkey: 'alt+a',
   })
 })
 
@@ -1180,6 +1197,7 @@ test('should set mod to true in hotkey object if listening to mod', async () => 
     mod: true,
     useKey: false,
     isSequence: false,
+    hotkey: 'mod+a',
   })
 })
 
@@ -1201,6 +1219,7 @@ test('should set meta to true in hotkey object if listening to meta', async () =
     mod: false,
     useKey: false,
     isSequence: false,
+    hotkey: 'meta+a',
   })
 })
 
@@ -1222,6 +1241,7 @@ test('should set multiple modifiers to true in hotkey object if listening to mul
     mod: true,
     useKey: false,
     isSequence: false,
+    hotkey: 'mod+shift+a',
   })
 })
 
@@ -1323,6 +1343,7 @@ test('should call preventDefault option function with hotkey and keyboard event'
     mod: false,
     useKey: false,
     isSequence: false,
+    hotkey: 'a',
   })
 })
 


### PR DESCRIPTION
According to the documentation, `useHotkeys` should have a `hotkey` property containing the pressed hotkey. The hotkey needs to be trimmed so it does not contain any leading spaces from combinations such as `ctrl+a, shift+a`.

Fixes #1286.