### PR TITLE
Include aria roles in ignores

### DIFF
--- a/packages/documentation/docs/api/use-hotkeys.mdx
+++ b/packages/documentation/docs/api/use-hotkeys.mdx
@@ -177,7 +177,7 @@ const options = {
 ```ts
 // Type Definitions
 type Trigger = boolean | ((keyboardEvent: KeyboardEvent, hotkeysEvent: HotkeysEvent) => boolean)
-type FormTags = 'input' | 'textarea' | 'select' | 'INPUT' | 'TEXTAREA' | 'SELECT';
+type FormTags = 'input' | 'textarea' | 'select' | 'INPUT' | 'TEXTAREA' | 'SELECT' | 'searchbox' | 'slider' | 'spinbutton' | 'menuitem' | 'menuitemcheckbox' | 'menuitemradio' | 'option' | 'radio' | 'textbox';
 
 type Options = {
   enabled?: Trigger
@@ -213,10 +213,10 @@ of the callback and `true` to __allow__ the callback to be triggered. You can al
 enableOnFormTags: string[] // default: undefined
 ```
 
-Normally we do not want a hotkey being triggered while a user types something into an input field. In some cases however
+Normally we do not want a hotkey being triggered while a user types something into an input field or a custom input that uses ARIA roles. In some cases however
 this might desirable. We can enable the callback trigger for an input tag using the following values:
 
-`INPUT`, `TEXTAREA`, `SELECT`
+`INPUT`, `TEXTAREA`, `SELECT`, `ROLE_NAME_HERE`
 
 ##### `ignoreEventWhen`
 

--- a/packages/react-hotkeys-hook/src/lib/types.ts
+++ b/packages/react-hotkeys-hook/src/lib/types.ts
@@ -1,6 +1,6 @@
 import type { DependencyList } from 'react'
 
-export type FormTags = 'input' | 'textarea' | 'select' | 'INPUT' | 'TEXTAREA' | 'SELECT'
+export type FormTags = 'input' | 'textarea' | 'select' | 'INPUT' | 'TEXTAREA' | 'SELECT' | 'searchbox' | 'slider' | 'spinbutton' | 'menuitem' | 'menuitemcheckbox' | 'menuitemradio' | 'option' | 'radio' | 'textbox'
 export type Keys = string | readonly string[]
 export type Scopes = string | readonly string[]
 

--- a/packages/react-hotkeys-hook/src/lib/validators.ts
+++ b/packages/react-hotkeys-hook/src/lib/validators.ts
@@ -16,8 +16,11 @@ export function isHotkeyEnabled(e: KeyboardEvent, hotkey: Hotkey, enabled?: Trig
   return enabled === true || enabled === undefined
 }
 
+// these are ARIA roles that are considered form fields
+const FORM_TAGS_AND_ROLES: readonly FormTags[] = ['input', 'textarea', 'select', 'searchbox', 'slider', 'spinbutton', 'menuitem', 'menuitemcheckbox', 'menuitemradio', 'option', 'radio', 'textbox'];
+
 export function isKeyboardEventTriggeredByInput(ev: KeyboardEvent): boolean {
-  return isHotkeyEnabledOnTag(ev, ['input', 'textarea', 'select'])
+  return isHotkeyEnabledOnTag(ev, FORM_TAGS_AND_ROLES);
 }
 
 export function isHotkeyEnabledOnTag(
@@ -25,18 +28,21 @@ export function isHotkeyEnabledOnTag(
   enabledOnTags: readonly FormTags[] | boolean = false,
 ): boolean {
   const { target, composed } = event
-
+  
   let targetTagName: EventTarget | string | undefined | null = undefined
+  let targetRole: string | undefined | null = undefined
 
   if (isCustomElement(target as HTMLElement) && composed) {
     targetTagName = event.composedPath()[0] && (event.composedPath()[0] as HTMLElement).tagName
+    targetRole = event.composedPath()[0] && (event.composedPath()[0] as HTMLElement).role
   } else {
     targetTagName = target && (target as HTMLElement).tagName
+    targetRole = target && (target as HTMLElement).role
   }
 
   if (isReadonlyArray(enabledOnTags)) {
     return Boolean(
-      targetTagName && enabledOnTags && enabledOnTags.some((tag) => tag.toLowerCase() === targetTagName.toLowerCase()),
+      targetTagName && enabledOnTags && enabledOnTags.some((tag) => tag.toLowerCase() === targetTagName.toLowerCase() || tag === targetRole),
     )
   }
 

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -685,6 +685,29 @@ test('should be disabled on form tags by default', async () => {
   expect(getByTestId('form-tag')).toHaveValue('A')
 })
 
+test('should be disabled on aria form roles by default', async () => {
+  const user = userEvent.setup()
+  const callback = vi.fn()
+  const formCallback = vi.fn()
+  const Component = ({ cb }: { cb: HotkeyCallback }) => {
+    useHotkeys<HTMLDivElement>('a', cb)
+
+    return <div role={'searchbox'} tabIndex={0} onKeyDown={formCallback} data-testid={'form-tag'} />
+  }
+
+  const { getByTestId } = render(<Component cb={callback} />)
+
+  await user.keyboard('A')
+
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  await user.click(getByTestId('form-tag'))
+  await user.keyboard('A')
+
+  expect(callback).toHaveBeenCalledTimes(1)
+  expect(formCallback).toHaveBeenCalledTimes(1)
+})
+
 test('should be enabled on given form tags', async () => {
   const user = userEvent.setup()
   const callback = vi.fn()


### PR DESCRIPTION
In addition to ignoring key presses on form fields, this ignores presses on custom form elements that use the ARIA role attribute. This will allow people to create custom inputs, or use form libraries.