### PR TITLE
Fix: should still test for modifier keys when useKey is true

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/validators.ts
+++ b/packages/react-hotkeys-hook/src/lib/validators.ts
@@ -93,13 +93,10 @@ export const isHotkeyMatchingKeyboardEvent = (e: KeyboardEvent, hotkey: Hotkey, 
 
   const mappedCode = mapCode(code)
 
-  if (useKey && keys?.length === 1 && keys.includes(producedKey)) {
-    return true
-  }
-
   if (
     !keys?.includes(mappedCode) &&
-    !['ctrl', 'control', 'unknown', 'meta', 'alt', 'shift', 'os'].includes(mappedCode)
+    !['ctrl', 'control', 'unknown', 'meta', 'alt', 'shift', 'os'].includes(mappedCode) &&
+    !(useKey && keys?.includes(producedKey))
   ) {
     return false
   }
@@ -128,6 +125,11 @@ export const isHotkeyMatchingKeyboardEvent = (e: KeyboardEvent, hotkey: Hotkey, 
         return false
       }
     }
+  }
+
+  // Check if the key matches when useKey is enabled
+  if (useKey && keys?.length === 1 && keys.includes(producedKey)) {
+    return true
   }
 
   // All modifiers are correct, now check the key

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -1473,6 +1473,30 @@ test('Should ignore modifiers if option is set', async () => {
   expect(callback).toHaveBeenCalledTimes(2)
 })
 
+test("Should test for modifiers when useKey is true", async () => {
+  const user = userEvent.setup()
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('meta+.', callback, { useKey: true }))
+  renderHook(() => useHotkeys('shift+a', callback, { useKey: true }))
+
+  await user.keyboard('{Meta>}.{/Meta}')
+
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  await user.keyboard('.')
+
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  await user.keyboard('{Shift>}a{/Shift}')
+
+  expect(callback).toHaveBeenCalledTimes(2)
+
+  await user.keyboard('a')
+
+  expect(callback).toHaveBeenCalledTimes(2)
+});
+
 
 test('should respect dependencies array if they are passed', async () => {
   function Fixture() {


### PR DESCRIPTION
Setting `useKey: true` shouldn't disable modifier checks.