### PR TITLE
feat: add metadata support for hotkeys

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/parseHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/parseHotkeys.ts
@@ -39,6 +39,7 @@ export function parseHotkey(
   sequenceSplitKey = '>',
   useKey = false,
   description?: string,
+  metadata?: Record<string, unknown>
 ): Hotkey {
   let keys: string[] = []
   let isSequence = false
@@ -77,5 +78,6 @@ export function parseHotkey(
     description,
     isSequence,
     hotkey,
+    metadata
   }
 }

--- a/packages/react-hotkeys-hook/src/lib/types.ts
+++ b/packages/react-hotkeys-hook/src/lib/types.ts
@@ -43,6 +43,7 @@ export type Hotkey = KeyboardModifiers & {
   description?: string
   isSequence?: boolean
   hotkey: string
+  metadata?: Record<string, unknown>
 }
 
 export type HotkeysEvent = Hotkey
@@ -86,6 +87,8 @@ export type Options = {
   sequenceTimeoutMs?: number
   // The character to split the sequence of keys. (Default: >)
   sequenceSplitKey?: string
+  // MetaData | Custom data to store and retrieve with the hotkey (Default: undefined)
+  metadata?: Record<string, unknown>
 }
 
 export type OptionsOrDependencyArray = Options | DependencyList

--- a/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
@@ -104,6 +104,7 @@ export default function useHotkeys<T extends HTMLElement>(
           memoisedOptions?.sequenceSplitKey,
           memoisedOptions?.useKey,
           memoisedOptions?.description,
+          memoisedOptions?.metadata,
         )
 
         if (hotkey.isSequence) {
@@ -216,6 +217,7 @@ export default function useHotkeys<T extends HTMLElement>(
             memoisedOptions?.sequenceSplitKey,
             memoisedOptions?.useKey,
             memoisedOptions?.description,
+            memoisedOptions?.metadata,
           ),
         ),
       )
@@ -236,6 +238,7 @@ export default function useHotkeys<T extends HTMLElement>(
               memoisedOptions?.sequenceSplitKey,
               memoisedOptions?.useKey,
               memoisedOptions?.description,
+              memoisedOptions?.metadata,
             ),
           ),
         )

--- a/packages/react-hotkeys-hook/src/test/useHotkeysContext.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeysContext.test.tsx
@@ -1,0 +1,85 @@
+import { renderHook } from '@testing-library/react'
+import { HotkeysProvider, useHotkeysContext, useHotkeys } from '../lib'
+import type { ReactNode } from 'react'
+import { test, expect } from 'vitest'
+
+test('should return hotkey with correct keys', () => {
+  const useIntegratedHotkeys = () => {
+    useHotkeys('ctrl+a', () => null)
+
+    return useHotkeysContext()
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider>{children}</HotkeysProvider>
+  )
+
+  const { result } = renderHook(useIntegratedHotkeys, {
+    wrapper,
+  })
+
+  expect(result.current.hotkeys).toHaveLength(1)
+  expect(result.current.hotkeys[0].hotkey).toEqual('ctrl+a')
+})
+
+test('should return hotkey with correct scope', () => {
+  const useIntegratedHotkeys = () => {
+    useHotkeys('ctrl+b', () => null, { scopes: ['scope'] })
+
+    return useHotkeysContext()
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider initiallyActiveScopes={['scope']}>{children}</HotkeysProvider>
+  )
+
+  const { result } = renderHook(useIntegratedHotkeys, {
+    wrapper,
+  })
+
+  expect(result.current.hotkeys).toHaveLength(1)
+  expect(result.current.hotkeys[0].hotkey).toEqual('ctrl+b')
+})
+
+test('should not return hotkey with different scope', () => {
+  const useIntegratedHotkeys = () => {
+    useHotkeys('ctrl+b', () => null, { scopes: ['differentScope'] })
+
+    return useHotkeysContext()
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider initiallyActiveScopes={['scope']}>{children}</HotkeysProvider>
+  )
+
+  const { result } = renderHook(useIntegratedHotkeys, {
+    wrapper,
+  })
+
+  console.log(result.current.hotkeys)
+  expect(result.current.hotkeys).toHaveLength(0)
+})
+
+test('should return hotkey with correct description and metadata', () => {
+  const useIntegratedHotkeys = () => {
+    useHotkeys('ctrl+c', () => null, {
+      description: 'Copy text',
+      metadata: { category: 'editing', priority: 'high' }
+    })
+
+    return useHotkeysContext()
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <HotkeysProvider>{children}</HotkeysProvider>
+  )
+
+  const { result } = renderHook(useIntegratedHotkeys, {
+    wrapper,
+  })
+
+  expect(result.current.hotkeys).toHaveLength(1)
+  expect(result.current.hotkeys[0].hotkey).toEqual('ctrl+c')
+  expect(result.current.hotkeys[0].description).toEqual('Copy text')
+  expect(result.current.hotkeys[0].metadata).toEqual({ category: 'editing', priority: 'high' })
+})


### PR DESCRIPTION
Summary:
- Added metadata field to Hotkey type to allow storing custom data with hotkeys
- Extended Options interface with metadata property for configuring custom data
- Updated parseHotkey function to accept and include metadata parameter
- Propagated metadata support through useHotkeys hook implementation
- Added TypeScript type definition for metadata as Record<string, unknown>

UseCase:
- adding metadata that can be used later when accessing the keys via `useHotkeysContext` hook