### PR TITLE
Add ignoreRepeat option to skip callback on held keys

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/types.ts
+++ b/packages/react-hotkeys-hook/src/lib/types.ts
@@ -87,6 +87,8 @@ export type Options = {
   sequenceTimeoutMs?: number
   // The character to split the sequence of keys. (Default: >)
   sequenceSplitKey?: string
+  // Ignore repeated events when the key is held down. (Default: false)
+  ignoreRepeat?: boolean
   // MetaData | Custom data to store and retrieve with the hotkey (Default: undefined)
   metadata?: Record<string, unknown>
 }

--- a/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
@@ -67,6 +67,10 @@ export default function useHotkeys<T extends HTMLElement>(
     let sequenceTimer: NodeJS.Timeout | undefined
 
     const listener = (e: KeyboardEvent, isKeyUp = false) => {
+      if (memoisedOptions?.ignoreRepeat && e.repeat) {
+        return
+      }
+
       if (isKeyboardEventTriggeredByInput(e) && !isHotkeyEnabledOnTag(e, memoisedOptions?.enableOnFormTags)) {
         return
       }

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -1707,6 +1707,67 @@ test('should be disabled on form tags inside custom elements by default', async 
   expect(within(getByTestId('form-tag').shadowRoot).getByTestId('input')).toHaveValue('A')
 })
 
+test('should not trigger callback on repeat events when ignoreRepeat is set to true', () => {
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('a', callback, { ignoreRepeat: true }))
+
+  // First keydown (not a repeat) should trigger
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: false, bubbles: true }))
+
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  // Repeated keydown events (held key) should not trigger
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: true, bubbles: true }))
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: true, bubbles: true }))
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: true, bubbles: true }))
+
+  expect(callback).toHaveBeenCalledTimes(1)
+})
+
+test('should trigger callback on repeat events by default', () => {
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('a', callback))
+
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: false, bubbles: true }))
+
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: true, bubbles: true }))
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: true, bubbles: true }))
+
+  expect(callback).toHaveBeenCalledTimes(3)
+})
+
+test('should trigger callback on repeat events when ignoreRepeat is set to false', () => {
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('a', callback, { ignoreRepeat: false }))
+
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: false, bubbles: true }))
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: true, bubbles: true }))
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', repeat: true, bubbles: true }))
+
+  expect(callback).toHaveBeenCalledTimes(3)
+})
+
+test('should not trigger callback on repeat events for modifier combinations when ignoreRepeat is set', () => {
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('meta+a', callback, { ignoreRepeat: true }))
+
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Meta', code: 'MetaLeft', metaKey: true, repeat: false, bubbles: true }))
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', metaKey: true, repeat: false, bubbles: true }))
+
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', metaKey: true, repeat: true, bubbles: true }))
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', metaKey: true, repeat: true, bubbles: true }))
+
+  expect(callback).toHaveBeenCalledTimes(1)
+})
+
 test('Should trigger only produced key hotkeys', async () => {
   const user = userEvent.setup()
 


### PR DESCRIPTION
## Summary
- Adds a new `ignoreRepeat` option to `Options` that prevents the hotkey callback from firing repeatedly when a key is held down
- Uses the native `KeyboardEvent.repeat` property to detect held keys and early-returns from the listener when `ignoreRepeat` is enabled

## Usage

```tsx
useHotkeys('a', () => {
  console.log('fires only once per key press')
}, { ignoreRepeat: true })
```

## Test plan
- [ ] Verify that with `ignoreRepeat: true`, holding a key only fires the callback once
- [ ] Verify that without the option (or `ignoreRepeat: false`), the default repeat behavior is unchanged
- [ ] Verify the option works alongside other options like `keyup`, `keydown`, and `preventDefault`