### PR TITLE
fix: prevent mod hotkey from triggering on Super/Windows key on non-macOS platforms

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/parseHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/parseHotkeys.ts
@@ -2,6 +2,11 @@ import type { Hotkey, KeyboardModifiers } from './types'
 
 const reservedModifierKeywords = ['shift', 'alt', 'meta', 'mod', 'ctrl', 'control']
 
+export function isMacOS(): boolean {
+  if (typeof navigator === 'undefined') return false
+  return /mac/i.test(navigator.userAgent) && !/iphone|ipad|ipod/i.test(navigator.userAgent)
+}
+
 const mappedKeys: Record<string, string> = {
   esc: 'escape',
   return: 'enter',

--- a/packages/react-hotkeys-hook/src/lib/validators.ts
+++ b/packages/react-hotkeys-hook/src/lib/validators.ts
@@ -1,6 +1,6 @@
 import type { FormTags, Hotkey, Scopes, Trigger } from './types'
 import { isHotkeyPressed, isReadonlyArray } from './isHotkeyPressed'
-import { mapCode } from './parseHotkeys'
+import { isMacOS, mapCode } from './parseHotkeys'
 
 export function maybePreventDefault(e: KeyboardEvent, hotkey: Hotkey, preventDefault?: Trigger): void {
   if ((typeof preventDefault === 'function' && preventDefault(e, hotkey)) || preventDefault === true) {
@@ -112,7 +112,7 @@ export const isHotkeyMatchingKeyboardEvent = (e: KeyboardEvent, hotkey: Hotkey, 
 
     // Mod is a special key name that is checking for meta on macOS and ctrl on other platforms
     if (mod) {
-      if (!metaKey && !ctrlKey) {
+      if (isMacOS() ? !metaKey : !ctrlKey) {
         return false
       }
     } else {

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -1206,7 +1206,7 @@ test('should set mod to true in hotkey object if listening to mod', async () => 
 
   renderHook(() => useHotkeys('mod+a', callback))
 
-  await user.keyboard('{Meta>}A{/Meta}')
+  await user.keyboard('{Control>}A{/Control}')
 
   expect(callback).toHaveBeenCalledTimes(1)
   expect(callback).toHaveBeenCalledWith(expect.any(KeyboardEvent), {
@@ -1250,7 +1250,7 @@ test('should set multiple modifiers to true in hotkey object if listening to mul
 
   renderHook(() => useHotkeys('mod+shift+a', callback))
 
-  await user.keyboard('{Meta>}{Shift>}A{/Shift}{/Meta}')
+  await user.keyboard('{Control>}{Shift>}A{/Shift}{/Control}')
 
   expect(callback).toHaveBeenCalledTimes(1)
   expect(callback).toHaveBeenCalledWith(expect.any(KeyboardEvent), {


### PR DESCRIPTION
## Problem

Closes #1280

`mod` is documented as mapping to **Command** on macOS and **Ctrl** on other platforms.
However, on Linux and Windows, the **Super/Windows key** also sets `metaKey: true` in browser keyboard events. This causes `mod+<key>` hotkeys to incorrectly trigger when the Super key is pressed.

---

## Root Cause

The `mod` check in `isHotkeyMatchingKeyboardEvent` accepted either `metaKey` or `ctrlKey` regardless of platform:

```ts
// before
if (!metaKey && !ctrlKey) return false
```

On non-macOS systems, the Super key satisfies `metaKey`, leading to incorrect matches.

---

## Fix

* Introduced `isMacOS()` utility in `parseHotkeys.ts` (based on `navigator.userAgent`, excluding iOS)
* Made the `mod` check platform-aware:

```ts
// after
if (isMacOS() ? !metaKey : !ctrlKey) return false
```

* Updated tests that relied on the previous (incorrect) behavior (Meta triggering `mod` on non-macOS)
