### PR TITLE
fix: dynamic enabled option no longer triggers event listeners in v5.3.0

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
@@ -23,10 +23,16 @@ const stopPropagation = (e: KeyboardEvent): void => {
 const useSafeLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 // Strip function properties from options so that inline callbacks don't trigger constant re-registration.
-function getSerializableOptions(options?: Options): Omit<Options, 'enabled' | 'preventDefault' | 'ignoreEventWhen'> | undefined {
+// Preserve boolean/undefined `enabled` so that toggling it dynamically re-runs the effect.
+function getSerializableOptions(options?: Options): Omit<Options, 'preventDefault' | 'ignoreEventWhen'> | undefined {
   if (!options) return undefined
   const { enabled: _enabled, preventDefault: _preventDefault, ignoreEventWhen: _ignoreEventWhen, ...rest } = options
-  return rest
+
+  if (typeof _enabled === 'function') {
+    return rest
+  }
+
+  return { ...rest, enabled: _enabled }
 }
 
 export default function useHotkeys<T extends HTMLElement>(

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -976,6 +976,46 @@ test('should bind the event and execute the callback if enabled is set to a func
   expect(callback).toHaveBeenCalledTimes(2)
 })
 
+test('should dynamically attach and detach listeners when enabled boolean changes', async () => {
+  const user = userEvent.setup()
+  const callback = vi.fn()
+
+  const { rerender } = renderHook<void, HookParameters>(({ keys, options }) => useHotkeys(keys, callback, options), {
+    initialProps: {
+      keys: 'a',
+      options: {
+        enabled: false,
+      },
+    },
+  })
+
+  await user.keyboard('A')
+
+  expect(callback).toHaveBeenCalledTimes(0)
+
+  rerender({
+    keys: 'a',
+    options: {
+      enabled: true,
+    },
+  })
+
+  await user.keyboard('A')
+
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  rerender({
+    keys: 'a',
+    options: {
+      enabled: false,
+    },
+  })
+
+  await user.keyboard('A')
+
+  expect(callback).toHaveBeenCalledTimes(1)
+})
+
 test('should return a ref', async () => {
   const callback = vi.fn()
 


### PR DESCRIPTION
## Problem
In v5.3.0, hotkeys initialized with `enabled: false` and later updated to `enabled: true` never attach their event listeners. This is a regression from v5.2.4.

The root cause is the options optimization in `getSerializableOptions`, which strips `enabled` entirely. Since `enabled` is no longer in `memoisedOptions` and not in the effect dependency array, toggling it doesn't trigger a re-run of the layout effect.

## Fix
`getSerializableOptions` now preserves boolean/undefined `enabled` while still stripping function values (`preventDefault`, `ignoreEventWhen`, and function-based `enabled`). This means:

- Boolean `enabled` changes are detected by `useDeepEqualMemo` and correctly re-run the effect to attach/detach listeners.
- Function-based `enabled` remains ref-driven to avoid constant re-registration from inline callbacks.

## Test
Added a new test: `should dynamically attach and detach listeners when enabled boolean changes` that verifies the full toggle cycle (false → true → false).

Fixes #1332