### PR TITLE
docs: document symbol and punctuation keys (closes #1303)

### DIFF
--- a/packages/documentation/docs/documentation/useHotkeys/ignore-layouts.mdx
+++ b/packages/documentation/docs/documentation/useHotkeys/ignore-layouts.mdx
@@ -42,3 +42,90 @@ function ExampleComponent() {
 ```
 
 Now the hotkey only triggers when the user produces the `!` character, regardless of which physical keys they press. On a standard US keyboard, `shift+1` and `!` are equivalent, but on other layouts they may differ. Choose `useKey: true` when the character matters more than the physical keystroke.
+
+## Symbol and punctuation keys
+
+Shortcuts that involve symbol or punctuation keys like `=`, `+`, `;`, `,`, `?`, or `/` are a common source of confusion. The same two approaches apply, but the string you pass to `useHotkeys` looks different depending on which one you choose.
+
+### Listening to the physical key
+
+Pass the physical key's [`KeyboardEvent.code`](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values) name. These names are derived from the US layout and stay the same regardless of which layout the user actually uses:
+
+| Character on US layout | Physical key code |
+|------------------------|-------------------|
+| `-`                    | `Minus`           |
+| `=`                    | `Equal`           |
+| `[`                    | `BracketLeft`     |
+| `]`                    | `BracketRight`    |
+| `\`                    | `Backslash`       |
+| `;`                    | `Semicolon`       |
+| `'`                    | `Quote`           |
+| `,`                    | `Comma`           |
+| `.`                    | `Period`          |
+| `/`                    | `Slash`           |
+| `` ` ``                | `Backquote`       |
+
+For example, to listen to the physical `;` key — regardless of layout — pass the code name:
+
+```jsx live
+function ExampleComponent() {
+  const [count, setCount] = useState(0)
+  useHotkeys('Semicolon', () => setCount(prevCount => prevCount + 1))
+
+  return (
+    <span>Pressed the ';' key {count} times.</span>
+  )
+}
+```
+
+The code names are case-insensitive, so `Semicolon` and `semicolon` behave the same. The same applies when you combine them with modifiers:
+
+```js
+useHotkeys('ctrl+Equal', zoomIn, { preventDefault: true })
+useHotkeys('ctrl+Minus', zoomOut, { preventDefault: true })
+useHotkeys('mod+Slash', toggleComment)
+```
+
+### Listening to the produced character
+
+If you care about the character itself — for example, you want `?` to open a help dialog whether the user is on a US layout (`shift+/`) or a German layout (`shift+ß`) — set `useKey: true` and pass the character directly:
+
+```jsx live
+function ExampleComponent() {
+  const [count, setCount] = useState(0)
+  useHotkeys('?', () => setCount(prevCount => prevCount + 1), { useKey: true })
+
+  return (
+    <span>Pressed '?' {count} times.</span>
+  )
+}
+```
+
+The same works for `=`, `+`, `/`, `;`, and most other printable characters:
+
+```js
+useHotkeys('+', addItem, { useKey: true })
+useHotkeys('=', resetZoom, { useKey: true })
+useHotkeys('/', focusSearch, { useKey: true })
+```
+
+:::caution Watch out for `+` and `,`
+By default, `+` is the [`splitKey`](/docs/api/use-hotkeys#splitkey) that joins keys in a combination, and `,` is the [`delimiter`](/docs/api/use-hotkeys#delimiter) that separates multiple hotkeys. To listen for those characters themselves, either switch to the physical-key approach (`Equal`/`Comma`) or change the option:
+
+```js
+// Listen to the '+' character by changing the splitKey
+useHotkeys('ctrl-+', addItem, { splitKey: '-' })
+```
+:::
+
+### When to choose which
+
+| You want…                                                                                              | Use                                  |
+|--------------------------------------------------------------------------------------------------------|--------------------------------------|
+| Editor-style shortcuts that always work on the same physical key (e.g. `Ctrl+;` for "go to file")      | Physical key (`'ctrl+Semicolon'`)    |
+| A user-visible character that appears in your UI hint (e.g. "Press `?` for help")                      | `useKey: true`                       |
+| The numpad `+` instead of the main-row `+`                                                             | Physical key (`'NumpadAdd'`)         |
+
+:::note Why two approaches?
+On a US keyboard, `?` is produced by `Shift + Slash`. On a German keyboard, the same physical `Slash` key produces `-`, and `?` is produced elsewhere. Listening to the physical key gives you a stable position across layouts; listening to the produced character gives you a stable user-visible symbol.
+:::


### PR DESCRIPTION
## Summary

Closes #1303.

Adds a "Symbol and punctuation keys" section to the **Keyboard Layouts** docs page (`ignore-layouts.mdx`) that documents how to listen to `=`, `+`, `;`, `,`, `?`, `/`, and similar non-letter keys.

The section covers both supported approaches and explains when to choose each:

- **Physical-key approach** (`useHotkeys('Semicolon', …)`) — uses `KeyboardEvent.code` names (linked to MDN); layout-independent; recommended for editor-style shortcuts that always live on the same physical key (e.g. `Ctrl+;` for "go to file").
- **Produced-character approach** (`useHotkeys('?', …, { useKey: true })`) — character-driven; layout-dependent; recommended for shortcuts whose user-visible label is the character itself (e.g. "Press `?` for help").

Includes:

- A reference table mapping common symbols on a US layout to their `KeyboardEvent.code` names (`-` → `Minus`, `=` → `Equal`, `;` → `Semicolon`, etc.).
- Two live (`jsx live`) examples — one per approach — so readers can verify behavior directly on the docs site.
- A `:::caution` block calling out the `+` / `,` defaults collision with `splitKey` / `delimiter`, with the documented workaround.
- A "When to choose which" table that maps user intent → recommendation.
- A `:::note` clarifying why both approaches exist, using a US-vs-German layout example for the same physical `Slash` key.

This is the docs-only request kenwuuu raised in #1303 in August 2025; no PR has been opened for it since.

## Motivation

This question recurs in issues (#1264, #1316, #1300) and Stack Overflow threads. The current docs only mention `useKey: true` with a single `!` example and don't list any `KeyboardEvent.code` names, which leaves users to guess that `Semicolon`, `Equal`, etc. are the right strings.

## Files changed

- `packages/documentation/docs/documentation/useHotkeys/ignore-layouts.mdx` — added a new H2 section after the existing two options (+87 lines, no removals)

## Tests

This is a docs-only change. No tests added.

Verified locally:

- `npm run build:documentation` — Docusaurus production build succeeds (server 32s, client 58s, no MDX warnings)
- `npm run test` — Vitest: 158 passed, 4 skipped, 0 failed
- `npm run build` — library build: 10.66 kB → 3.46 kB gzip, no regressions
- `npx @biomejs/biome lint packages` — 0 issues
- `npx @biomejs/biome format packages` — 0 fixes needed

## Notes for the maintainer

- All `jsx live` blocks follow the conventions of the existing `basic-usage.mdx` / `ignore-layouts.mdx` (no imports, implicit `useState`).
- Cross-links use the existing `/docs/api/use-hotkeys#splitkey` style.
- No new dependencies, no API changes.
- Authored by a human (Nicoreia, GitHub @Nicoreia) with AI tooling assistance; the change was hand-reviewed against the existing tone, `AGENTS.md`, and `parseHotkeys.ts` to make sure the recommended code patterns actually work today.
