### PR TITLE
fix: ignore AltGraph for single-key hotkeys without modifiers (closes #1143)

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/validators.ts
+++ b/packages/react-hotkeys-hook/src/lib/validators.ts
@@ -88,7 +88,13 @@ export const isHotkeyMatchingKeyboardEvent = (e: KeyboardEvent, hotkey: Hotkey, 
 
   const mappedCode = mapCode(code)
 
+  const hasHotkeyModifiers = !!(alt || ctrl || shift || meta || mod)
+
   if (useKey && keys?.length === 1 && keys.includes(producedKey.toLowerCase())) {
+    if (!ignoreModifiers && !hasHotkeyModifiers && e.getModifierState?.('AltGraph')) {
+      return false
+    }
+
     return true
   }
 
@@ -100,6 +106,10 @@ export const isHotkeyMatchingKeyboardEvent = (e: KeyboardEvent, hotkey: Hotkey, 
   }
 
   if (!ignoreModifiers) {
+    if (!hasHotkeyModifiers && keys?.length === 1 && e.getModifierState?.('AltGraph')) {
+      return false
+    }
+
     // We check the pressed keys for compatibility with the keyup event. In keyup events the modifier flags are not set.
     if (alt !== altKey && mappedCode !== 'alt') {
       return false

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -1583,6 +1583,32 @@ test('should not trigger callback when modifier is pressed while holding unrelat
   expect(callback).toHaveBeenCalledTimes(0)
 })
 
+test('should not trigger single-key hotkey when AltGraph modifier is active', async () => {
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('c', callback))
+
+  const keyDownWithAltGraph = createEvent.keyDown(document, {
+    key: 'c',
+    code: 'KeyC',
+  })
+
+  keyDownWithAltGraph.getModifierState = (key: string) => key === 'AltGraph'
+
+  fireEvent(document, keyDownWithAltGraph)
+
+  expect(callback).not.toHaveBeenCalled()
+
+  const keyDownWithoutAltGraph = createEvent.keyDown(document, {
+    key: 'c',
+    code: 'KeyC',
+  })
+
+  fireEvent(document, keyDownWithoutAltGraph)
+
+  expect(callback).toHaveBeenCalledTimes(1)
+})
+
 test('should respect dependencies array if they are passed', async () => {
   function Fixture() {
     const [count, setCount] = useState(0)


### PR DESCRIPTION
## Summary

- Fixes #1143: single-key hotkeys (e.g. `c`) no longer fire while `AltGraph` is held.
- Uses `event.getModifierState('AltGraph')` because AltGr is not always reflected in `altKey`/`ctrlKey`.

Separate from open docs PR #1338.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (includes new regression test)
- [x] `npm run build`
- [ ] Manual check on Windows (Chrome/Edge) with real AltGr + single-key binding

## AI disclosure

Prepared with AI assistance; reviewed before submission.
