### PR TITLE
fix: respect AltGraph as a modifier

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/validators.ts
+++ b/packages/react-hotkeys-hook/src/lib/validators.ts
@@ -1,6 +1,6 @@
-import type { FormTags, Hotkey, Scopes, Trigger } from './types'
 import { isHotkeyPressed, isReadonlyArray } from './isHotkeyPressed'
 import { isMacOS, mapCode } from './parseHotkeys'
+import type { FormTags, Hotkey, Scopes, Trigger } from './types'
 
 export function maybePreventDefault(e: KeyboardEvent, hotkey: Hotkey, preventDefault?: Trigger): void {
   if ((typeof preventDefault === 'function' && preventDefault(e, hotkey)) || preventDefault === true) {
@@ -87,6 +87,7 @@ export const isHotkeyMatchingKeyboardEvent = (e: KeyboardEvent, hotkey: Hotkey, 
   const { code, key: producedKey, ctrlKey, metaKey, shiftKey, altKey } = e
 
   const mappedCode = mapCode(code)
+  const altGraphKey = typeof e.getModifierState === 'function' && e.getModifierState('AltGraph')
 
   if (useKey && keys?.length === 1 && keys.includes(producedKey.toLowerCase())) {
     return true
@@ -122,6 +123,10 @@ export const isHotkeyMatchingKeyboardEvent = (e: KeyboardEvent, hotkey: Hotkey, 
       if (ctrl !== ctrlKey && mappedCode !== 'ctrl' && mappedCode !== 'control') {
         return false
       }
+    }
+
+    if (altGraphKey && !alt && !ctrl && !mod && !['alt', 'ctrl', 'control'].includes(mappedCode)) {
+      return false
     }
   }
 

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -1542,6 +1542,42 @@ test('Should test for modifiers by default', async () => {
   expect(callback).toHaveBeenCalledTimes(1)
 })
 
+test('should not trigger a single-key hotkey while AltGraph is active', () => {
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('c', callback))
+
+  const event = createEvent.keyDown(document, {
+    key: 'c',
+    code: 'KeyC',
+  })
+  Object.defineProperty(event, 'getModifierState', {
+    value: (key: string) => key === 'AltGraph',
+  })
+
+  fireEvent(document, event)
+
+  expect(callback).not.toHaveBeenCalled()
+})
+
+test('should trigger a single-key hotkey with AltGraph when modifiers are ignored', () => {
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('c', callback, { ignoreModifiers: true }))
+
+  const event = createEvent.keyDown(document, {
+    key: 'c',
+    code: 'KeyC',
+  })
+  Object.defineProperty(event, 'getModifierState', {
+    value: (key: string) => key === 'AltGraph',
+  })
+
+  fireEvent(document, event)
+
+  expect(callback).toHaveBeenCalledTimes(1)
+})
+
 test('Should ignore modifiers if option is set', async () => {
   const user = userEvent.setup()
 


### PR DESCRIPTION
Fixes #1143.

This treats an active AltGraph modifier as an additional modifier during normal hotkey matching, so a single-key shortcut like `c` no longer fires while AltGraph is held. The existing `ignoreModifiers: true` behavior is preserved.

Verification:

- `npm run -w packages/react-hotkeys-hook test -- --run src/test/useHotkeys.test.tsx -t "AltGraph"`
- `npm run -w packages/react-hotkeys-hook test -- --run src/test/useHotkeys.test.tsx`
- `npm run -w packages/react-hotkeys-hook build`
- `npx @biomejs/biome check packages/react-hotkeys-hook/src/lib/validators.ts packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx`
- `git diff --check`
