### PR TITLE
docs: add Safari scoped hotkeys troubleshooting

### DIFF
--- a/packages/documentation/docs/documentation/useHotkeys/scoping-hotkeys.mdx
+++ b/packages/documentation/docs/documentation/useHotkeys/scoping-hotkeys.mdx
@@ -49,7 +49,7 @@ function ScopedHotkey() {
   return (
     <>
       <p>The count is {count}. Click anywhere except the button to disable the hotkey.</p>
-      <button ref={ref}>
+      <button ref={ref} onClick={event => event.currentTarget.focus()}>
         Click me to enable the hotkey
       </button>
     </>
@@ -63,7 +63,7 @@ function SecondScopedHotkey() {
   return (
     <>
       <p>The count is {count}. Click anywhere except the button to disable the hotkey.</p>
-      <button ref={ref}>
+      <button ref={ref} onClick={event => event.currentTarget.focus()}>
         Click me to enable the hotkey
       </button>
     </>
@@ -79,7 +79,9 @@ render(
 )
 ```
 
-Now each hotkey only fires when its assigned button has focus. You can use this technique for any hotkey, not just duplicates.
+Now each hotkey only fires when its assigned button has focus. The click handler explicitly focuses the button so the demo
+also works in Safari, where clicking a button does not always move focus automatically. You can use this technique for any
+hotkey, not just duplicates.
 
 ***
 

--- a/packages/documentation/versioned_docs/version-4.x/documentation/hotkeys-provider.mdx
+++ b/packages/documentation/versioned_docs/version-4.x/documentation/hotkeys-provider.mdx
@@ -73,22 +73,6 @@ If your app is highly dynamic and you want to know which scopes are currently ac
 `enabledScopes` from the context.
 :::
 
-## Troubleshooting Safari button focus
-
-Safari does not always move focus to a `<button>` when it is clicked. In the example above, the scoped hotkey only runs
-while the element returned by `useHotkeys` owns focus. If the button does not become `document.activeElement` after the
-click, Safari leaves the scoped hotkey disabled even though the same demo works in browsers that focus buttons on click.
-
-When debugging Safari-specific scoped hotkey behavior:
-
-- Check `document.activeElement` after clicking the scoped element.
-- If the active element is still `body`, call `.focus()` from the click handler or attach the ref to a container that can
-  be focused explicitly.
-- For non-interactive containers, add `tabIndex={-1}` as shown below so the element can receive programmatic focus without
-  entering the normal tab order.
-- Keep browser-reserved shortcuts in mind; verify the behavior first with a simple shortcut before testing combinations
-  that Safari may intercept.
-
 ## Set initially active scopes
 
 You can set the initially active scopes by passing an array of strings to the `initiallyActiveScopes` prop of the `HotkeysProvider`.

--- a/packages/documentation/versioned_docs/version-4.x/documentation/hotkeys-provider.mdx
+++ b/packages/documentation/versioned_docs/version-4.x/documentation/hotkeys-provider.mdx
@@ -73,6 +73,56 @@ If your app is highly dynamic and you want to know which scopes are currently ac
 `enabledScopes` from the context.
 :::
 
+## Troubleshooting scoped hotkeys in Safari
+
+Safari can be stricter than other browsers about which element currently owns keyboard focus. If a scoped hotkey works
+in Chrome or Firefox but not in Safari, check the focus target before assuming that scopes are not enabled.
+
+- Make sure the component that registers the scoped hotkey is rendered inside a `<HotkeysProvider>`.
+- Verify that the scope you pass to `useHotkeys` is active by reading `enabledScopes` from `useHotkeysContext()`.
+- If you set `initiallyActiveScopes`, remember that the wildcard `*` scope is no longer active unless you include it.
+- If you use the ref returned by `useHotkeys`, Safari will only fire the hotkey when that element or one of its children has focus.
+- Non-interactive elements such as `<div>` and `<span>` need `tabIndex={0}` before Safari can focus them reliably.
+- Click or programmatically focus the scoped element before testing the shortcut.
+- Confirm with `document.activeElement` that Safari focused the element you expected.
+- If focus stays on `body`, move the hotkey to a focusable element or add `tabIndex` to the scoped container.
+- Hotkeys are ignored inside form controls by default so typing into inputs does not trigger app shortcuts.
+- Set `enableOnFormTags` when a scoped shortcut intentionally needs to work from an `input`, `textarea`, or `select`.
+- Set `enableOnContentEditable: true` when the focused target is a `contentEditable` editor.
+- Use `ignoreEventWhen` for custom editors that should sometimes opt out of global or scoped shortcuts.
+- Be careful with `preventDefault: true`; Safari may keep some reserved browser shortcuts for itself.
+- Prefer testing with a simple key such as `s` before debugging a browser-reserved combination such as `meta+l`.
+- If the shortcut includes `meta`, `alt`, or `ctrl`, check whether Safari already uses that combination for browser UI.
+- When using `preventDefault` as a function, log its return value to make sure it returns `true` for the failing shortcut.
+- Check whether both `keydown` and `keyup` are configured the way you expect.
+- If you only set `keyup: true`, add `keydown: true` as well when you want both events to trigger.
+- Log the `event.key`, `event.code`, and the hotkeys handler data from the callback while testing different keyboard layouts.
+- Try `ignoreModifiers: true` only when you want to match the produced character instead of the physical modifier combination.
+- Confirm that the component registering the hotkey is mounted when the scope is enabled.
+- Confirm that dependencies passed to `useHotkeys` do not leave the callback with stale scope or state values.
+- In iframes, pass the iframe `document` option so Safari attaches the listener to the focused document.
+- Retest after disabling browser extensions that capture keyboard shortcuts.
+- Build a minimal page with one `<HotkeysProvider>`, one active scope, and one focused button to isolate Safari-specific focus issues.
+
+A minimal debug helper can make the active scope and focus target visible while testing:
+
+```jsx
+import { useHotkeysContext } from 'react-hotkeys-hook';
+
+function ScopeDebug() {
+  const { enabledScopes } = useHotkeysContext();
+
+  return (
+    <pre>
+      {JSON.stringify({
+        enabledScopes,
+        activeElement: document.activeElement?.tagName,
+      })}
+    </pre>
+  )
+}
+```
+
 ## Set initially active scopes
 
 You can set the initially active scopes by passing an array of strings to the `initiallyActiveScopes` prop of the `HotkeysProvider`.

--- a/packages/documentation/versioned_docs/version-4.x/documentation/hotkeys-provider.mdx
+++ b/packages/documentation/versioned_docs/version-4.x/documentation/hotkeys-provider.mdx
@@ -73,55 +73,21 @@ If your app is highly dynamic and you want to know which scopes are currently ac
 `enabledScopes` from the context.
 :::
 
-## Troubleshooting scoped hotkeys in Safari
+## Troubleshooting Safari button focus
 
-Safari can be stricter than other browsers about which element currently owns keyboard focus. If a scoped hotkey works
-in Chrome or Firefox but not in Safari, check the focus target before assuming that scopes are not enabled.
+Safari does not always move focus to a `<button>` when it is clicked. In the example above, the scoped hotkey only runs
+while the element returned by `useHotkeys` owns focus. If the button does not become `document.activeElement` after the
+click, Safari leaves the scoped hotkey disabled even though the same demo works in browsers that focus buttons on click.
 
-- Make sure the component that registers the scoped hotkey is rendered inside a `<HotkeysProvider>`.
-- Verify that the scope you pass to `useHotkeys` is active by reading `enabledScopes` from `useHotkeysContext()`.
-- If you set `initiallyActiveScopes`, remember that the wildcard `*` scope is no longer active unless you include it.
-- If you use the ref returned by `useHotkeys`, Safari will only fire the hotkey when that element or one of its children has focus.
-- Non-interactive elements such as `<div>` and `<span>` need `tabIndex={0}` before Safari can focus them reliably.
-- Click or programmatically focus the scoped element before testing the shortcut.
-- Confirm with `document.activeElement` that Safari focused the element you expected.
-- If focus stays on `body`, move the hotkey to a focusable element or add `tabIndex` to the scoped container.
-- Hotkeys are ignored inside form controls by default so typing into inputs does not trigger app shortcuts.
-- Set `enableOnFormTags` when a scoped shortcut intentionally needs to work from an `input`, `textarea`, or `select`.
-- Set `enableOnContentEditable: true` when the focused target is a `contentEditable` editor.
-- Use `ignoreEventWhen` for custom editors that should sometimes opt out of global or scoped shortcuts.
-- Be careful with `preventDefault: true`; Safari may keep some reserved browser shortcuts for itself.
-- Prefer testing with a simple key such as `s` before debugging a browser-reserved combination such as `meta+l`.
-- If the shortcut includes `meta`, `alt`, or `ctrl`, check whether Safari already uses that combination for browser UI.
-- When using `preventDefault` as a function, log its return value to make sure it returns `true` for the failing shortcut.
-- Check whether both `keydown` and `keyup` are configured the way you expect.
-- If you only set `keyup: true`, add `keydown: true` as well when you want both events to trigger.
-- Log the `event.key`, `event.code`, and the hotkeys handler data from the callback while testing different keyboard layouts.
-- Try `ignoreModifiers: true` only when you want to match the produced character instead of the physical modifier combination.
-- Confirm that the component registering the hotkey is mounted when the scope is enabled.
-- Confirm that dependencies passed to `useHotkeys` do not leave the callback with stale scope or state values.
-- In iframes, pass the iframe `document` option so Safari attaches the listener to the focused document.
-- Retest after disabling browser extensions that capture keyboard shortcuts.
-- Build a minimal page with one `<HotkeysProvider>`, one active scope, and one focused button to isolate Safari-specific focus issues.
+When debugging Safari-specific scoped hotkey behavior:
 
-A minimal debug helper can make the active scope and focus target visible while testing:
-
-```jsx
-import { useHotkeysContext } from 'react-hotkeys-hook';
-
-function ScopeDebug() {
-  const { enabledScopes } = useHotkeysContext();
-
-  return (
-    <pre>
-      {JSON.stringify({
-        enabledScopes,
-        activeElement: document.activeElement?.tagName,
-      })}
-    </pre>
-  )
-}
-```
+- Check `document.activeElement` after clicking the scoped element.
+- If the active element is still `body`, call `.focus()` from the click handler or attach the ref to a container that can
+  be focused explicitly.
+- For non-interactive containers, add `tabIndex={-1}` as shown below so the element can receive programmatic focus without
+  entering the normal tab order.
+- Keep browser-reserved shortcuts in mind; verify the behavior first with a simple shortcut before testing combinations
+  that Safari may intercept.
 
 ## Set initially active scopes
 

--- a/packages/documentation/versioned_docs/version-4.x/documentation/useHotkeys/scoping-hotkeys.mdx
+++ b/packages/documentation/versioned_docs/version-4.x/documentation/useHotkeys/scoping-hotkeys.mdx
@@ -53,7 +53,7 @@ function ScopedHotkey() {
   return (
     <>
       <p>The count is {count}. Click anywhere except for the button to disable the hotkey.</p>
-      <button ref={ref}>
+      <button ref={ref} onClick={event => event.currentTarget.focus()}>
         Click me to enable the hotkey
       </button>
     </>
@@ -67,7 +67,7 @@ function SecondScopedHotkey() {
   return (
     <>
       <p>The count is {count}. Click anywhere except for the button to disable the hotkey.</p>
-      <button ref={ref}>
+      <button ref={ref} onClick={event => event.currentTarget.focus()}>
         Click me to enable the hotkey
       </button>
     </>
@@ -83,8 +83,9 @@ render(
 )
 ```
 
-As we can see only if the button receives focus the hotkey gets enabled. We also added a second component that
-listens to the same hotkey but only triggers if an assigned component receives focus.
+As we can see only if the button receives focus the hotkey gets enabled. The click handler explicitly focuses the button so
+the demo also works in Safari, where clicking a button does not always move focus automatically. We also added a second
+component that listens to the same hotkey but only triggers if an assigned component receives focus.
 
 We successfully scoped our duplicate global hotkey to their own components. This practice isn't restricted to duplicate
 hotkeys, we can use this technique to scope any hotkey we like.


### PR DESCRIPTION
## Summary
- Adds Safari-specific troubleshooting guidance for scoped hotkeys
- Covers focus requirements, active scope checks, form/contentEditable behavior, and preventDefault caveats
- Includes a minimal debug helper for checking active scopes and focused element

Fixes #1315