### PR TITLE
 Fix sequenceTimeoutMs and multiple sequence handling

### DIFF
--- a/packages/documentation/docs/documentation/useHotkeys/basic-usage.mdx
+++ b/packages/documentation/docs/documentation/useHotkeys/basic-usage.mdx
@@ -172,7 +172,7 @@ function ExampleComponent() {
 }
 ```
 
-Here the user has 10 seconds to complete the `g>h>i>j` sequence.
+Here the user has 10 seconds between each key to complete the `g>h>i>j` sequence (up to 30 seconds total for all four keys).
 
 ***
 

--- a/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
@@ -90,7 +90,7 @@ export default function useHotkeys<T extends HTMLElement>(
     }
 
     let recordedKeys: string[] = []
-    let sequenceTimer: ReturnType<typeof setTimeout> | undefined
+    let sequenceTimer: ReturnType<typeof setTimeout>[] = []
 
     const listener = (e: KeyboardEvent, isKeyUp = false) => {
       if (isKeyboardEventTriggeredByInput(e) && !isHotkeyEnabledOnTag(e, memoisedOptions?.enableOnFormTags)) {
@@ -116,7 +116,7 @@ export default function useHotkeys<T extends HTMLElement>(
         return
       }
 
-      parseKeysHookInput(_keys, memoisedOptions?.delimiter).forEach((key) => {
+      parseKeysHookInput(_keys, memoisedOptions?.delimiter).forEach((key, index) => {
         if (key.includes(memoisedOptions?.splitKey ?? '+') && key.includes(memoisedOptions?.sequenceSplitKey ?? '>')) {
           console.warn(
             `Hotkey ${key} contains both ${memoisedOptions?.splitKey ?? '+'} and ${memoisedOptions?.sequenceSplitKey ?? '>'} which is not supported.`,
@@ -134,8 +134,11 @@ export default function useHotkeys<T extends HTMLElement>(
         )
 
         if (hotkey.isSequence) {
-          // Set a timeout to check post which the sequence should reset
-          sequenceTimer = setTimeout(() => {
+          // Restart the timeout — if the next key isn't pressed in time, reset the sequence
+          if (sequenceTimer[index]) {
+            clearTimeout(sequenceTimer[index]);
+          }
+          sequenceTimer[index] = setTimeout(() => {
             recordedKeys = []
           }, memoisedOptions?.sequenceTimeoutMs ?? 1000)
 
@@ -151,8 +154,8 @@ export default function useHotkeys<T extends HTMLElement>(
           const expectedKey = hotkey.keys?.[recordedKeys.length - 1]
           if (currentKey !== expectedKey) {
             recordedKeys = []
-            if (sequenceTimer) {
-              clearTimeout(sequenceTimer)
+            if (sequenceTimer[index]) {
+              clearTimeout(sequenceTimer[index])
             }
             return
           }
@@ -161,8 +164,8 @@ export default function useHotkeys<T extends HTMLElement>(
           if (recordedKeys.length === hotkey.keys?.length) {
             cbRef.current(e, hotkey)
 
-            if (sequenceTimer) {
-              clearTimeout(sequenceTimer)
+            if (sequenceTimer[index]) {
+              clearTimeout(sequenceTimer[index])
             }
 
             recordedKeys = []
@@ -269,9 +272,7 @@ export default function useHotkeys<T extends HTMLElement>(
       }
 
       recordedKeys = []
-      if (sequenceTimer) {
-        clearTimeout(sequenceTimer)
-      }
+      sequenceTimer.forEach((timer) => clearTimeout(timer))
     }
   }, [ref, memoisedOptions, activeScopes, _keys])
 

--- a/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
@@ -89,7 +89,7 @@ export default function useHotkeys<T extends HTMLElement>(
       return
     }
 
-    let recordedKeys: string[] = []
+    let recordedKeys: string[][] = []
     let sequenceTimer: ReturnType<typeof setTimeout>[] = []
 
     const listener = (e: KeyboardEvent, isKeyUp = false) => {
@@ -124,6 +124,8 @@ export default function useHotkeys<T extends HTMLElement>(
           return
         }
 
+        recordedKeys[index] = recordedKeys[index] || [];
+
         const hotkey = parseHotkey(
           key,
           memoisedOptions?.splitKey,
@@ -139,7 +141,7 @@ export default function useHotkeys<T extends HTMLElement>(
             clearTimeout(sequenceTimer[index]);
           }
           sequenceTimer[index] = setTimeout(() => {
-            recordedKeys = []
+            recordedKeys[index] = []
           }, memoisedOptions?.sequenceTimeoutMs ?? 1000)
 
           const currentKey = hotkey.useKey ? e.key : mapCode(e.code)
@@ -149,11 +151,11 @@ export default function useHotkeys<T extends HTMLElement>(
             return
           }
 
-          recordedKeys.push(currentKey)
+          recordedKeys[index].push(currentKey)
 
-          const expectedKey = hotkey.keys?.[recordedKeys.length - 1]
+          const expectedKey = hotkey.keys?.[recordedKeys[index].length - 1]
           if (currentKey !== expectedKey) {
-            recordedKeys = []
+            recordedKeys[index] = []
             if (sequenceTimer[index]) {
               clearTimeout(sequenceTimer[index])
             }
@@ -161,14 +163,14 @@ export default function useHotkeys<T extends HTMLElement>(
           }
 
           // If the sequence is complete, trigger the callback
-          if (recordedKeys.length === hotkey.keys?.length) {
+          if (recordedKeys[index].length === hotkey.keys?.length) {
             cbRef.current(e, hotkey)
 
             if (sequenceTimer[index]) {
               clearTimeout(sequenceTimer[index])
             }
 
-            recordedKeys = []
+            recordedKeys[index] = []
           }
         } else {
           if (

--- a/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
+++ b/packages/react-hotkeys-hook/src/lib/useHotkeys.ts
@@ -124,7 +124,7 @@ export default function useHotkeys<T extends HTMLElement>(
           return
         }
 
-        recordedKeys[index] = recordedKeys[index] || [];
+        const rec = recordedKeys[index] ||= []
 
         const hotkey = parseHotkey(
           key,
@@ -137,11 +137,10 @@ export default function useHotkeys<T extends HTMLElement>(
 
         if (hotkey.isSequence) {
           // Restart the timeout — if the next key isn't pressed in time, reset the sequence
-          if (sequenceTimer[index]) {
-            clearTimeout(sequenceTimer[index]);
-          }
+          // clearTimeout with undefined is a no-op: https://developer.mozilla.org/en-US/docs/Web/API/Window/clearTimeout
+          clearTimeout(sequenceTimer[index])
           sequenceTimer[index] = setTimeout(() => {
-            recordedKeys[index] = []
+            rec.length = 0 // Clear in place so the `rec` reference stays valid
           }, memoisedOptions?.sequenceTimeoutMs ?? 1000)
 
           const currentKey = hotkey.useKey ? e.key : mapCode(e.code)
@@ -151,26 +150,20 @@ export default function useHotkeys<T extends HTMLElement>(
             return
           }
 
-          recordedKeys[index].push(currentKey)
+          rec.push(currentKey)
 
-          const expectedKey = hotkey.keys?.[recordedKeys[index].length - 1]
+          const expectedKey = hotkey.keys?.[rec.length - 1]
           if (currentKey !== expectedKey) {
-            recordedKeys[index] = []
-            if (sequenceTimer[index]) {
-              clearTimeout(sequenceTimer[index])
-            }
+            rec.length = 0
+            clearTimeout(sequenceTimer[index])
             return
           }
 
           // If the sequence is complete, trigger the callback
-          if (recordedKeys[index].length === hotkey.keys?.length) {
+          if (rec.length === hotkey.keys?.length) {
             cbRef.current(e, hotkey)
-
-            if (sequenceTimer[index]) {
-              clearTimeout(sequenceTimer[index])
-            }
-
-            recordedKeys[index] = []
+            clearTimeout(sequenceTimer[index])
+            rec.length = 0
           }
         } else {
           if (

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -502,6 +502,40 @@ test('should reset sequence when timeout occurs', async () => {
   expect(callback).toHaveBeenCalledTimes(1)
 })
 
+test('should treat sequenceTimeoutMs as a per-key timeout, not a total sequence timeout', async () => {
+  const user = userEvent.setup()
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('y>e>e>t', callback, { sequenceTimeoutMs: 200 }))
+
+  await user.keyboard('y')
+  vi.advanceTimersByTime(100)
+  await user.keyboard('e')
+  vi.advanceTimersByTime(100)
+  await user.keyboard('e')
+  vi.advanceTimersByTime(100)
+  await user.keyboard('t')
+
+  expect(callback).toHaveBeenCalledTimes(1)
+})
+
+test('should reset sequence when a single key gap exceeds sequenceTimeoutMs', async () => {
+  const user = userEvent.setup()
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('y>e>e>t', callback, { sequenceTimeoutMs: 200 }))
+
+  await user.keyboard('y')
+  vi.advanceTimersByTime(100)
+  await user.keyboard('e')
+  vi.advanceTimersByTime(300)
+  await user.keyboard('e')
+  vi.advanceTimersByTime(100)
+  await user.keyboard('t')
+
+  expect(callback).toHaveBeenCalledTimes(0)
+})
+
 test('should handle component unmount during sequence detection', async () => {
   const user = userEvent.setup()
   const callback = vi.fn()

--- a/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
+++ b/packages/react-hotkeys-hook/src/test/useHotkeys.test.tsx
@@ -536,6 +536,42 @@ test('should reset sequence when a single key gap exceeds sequenceTimeoutMs', as
   expect(callback).toHaveBeenCalledTimes(0)
 })
 
+test('should support multiple comma-separated sequences', async () => {
+  const user = userEvent.setup()
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('g>h>i, a>b>c', callback))
+
+  await user.keyboard('a')
+  await user.keyboard('b')
+  await user.keyboard('c')
+
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  await user.keyboard('g')
+  await user.keyboard('h')
+  await user.keyboard('i')
+
+  expect(callback).toHaveBeenCalledTimes(2)
+})
+
+test('should not let one sequence timer interfere with another', async () => {
+  const user = userEvent.setup()
+  const callback = vi.fn()
+
+  renderHook(() => useHotkeys('g>h>i, a>b>c', callback, { sequenceTimeoutMs: 500 }))
+
+  await user.keyboard('g')
+  vi.advanceTimersByTime(400)
+  await user.keyboard('a')
+  vi.advanceTimersByTime(400)
+  await user.keyboard('b')
+  vi.advanceTimersByTime(400)
+  await user.keyboard('c')
+
+  expect(callback).toHaveBeenCalledTimes(1)
+})
+
 test('should handle component unmount during sequence detection', async () => {
   const user = userEvent.setup()
   const callback = vi.fn()


### PR DESCRIPTION
Two bugs in sequence hotkey handling, fixed together because they touch the same code block.

Per-key timeout is also the right behavior — with a total timeout, users would have to type faster as sequences get longer.

## Bug 1: sequenceTimeoutMs is a total timeout, not per-key

The document says "1 second between each key", but the timer set on the 1st key was never cleared on subsequent matching keys. So for a 3-keys sequence with `sequenceTimeoutMs: 1000`, the entire sequence had to be completed within 1 second, not 1 second between each key.

Fix: `clearTimeout` before setting a new timer on each matching key press.

## Bug 2: multiple comma-separated sequences break each other

`useHotkeys('g>h>i, a>b>c', cb)` never works — `recordedKeys` and `sequenceTimer` were shared across all patterns in the `forEach` loop. The 2nd pattern's iteration corrupts the 1st state on every key press.

Fix: make `recordedKeys` and `sequenceTimer` per-pattern arrays indexed by the forEach index.

## Size

+20 bytes in gzip (3335 → 3355)
