### PR TITLE
Short-circuit deepEqual if values are ref-equal

### DIFF
--- a/packages/react-hotkeys-hook/src/lib/deepEqual.ts
+++ b/packages/react-hotkeys-hook/src/lib/deepEqual.ts
@@ -1,7 +1,12 @@
 export default function deepEqual(x?: unknown, y?: unknown): boolean {
-  return x && y && typeof x === 'object' && typeof y === 'object'
-    ? Object.keys(x).length === Object.keys(y).length &&
-        // @ts-expect-error TS7053
-        Object.keys(x).reduce((isEqual, key) => isEqual && deepEqual(x[key], y[key]), true)
-    : x === y
+  if (x === y) return true
+  return !!(
+    x &&
+    y &&
+    typeof x === 'object' &&
+    typeof y === 'object' &&
+    Object.keys(x).length === Object.keys(y).length &&
+    // @ts-expect-error TS7053
+    Object.keys(x).reduce((isEqual, key) => isEqual && deepEqual(x[key], y[key]), true)
+  )
 }

--- a/packages/react-hotkeys-hook/src/test/deepEqual.test.ts
+++ b/packages/react-hotkeys-hook/src/test/deepEqual.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from 'vitest'
+import deepEqual from '../lib/deepEqual'
+
+test('Should handle circular references in objects that are ref-equal', () => {
+  type Obj = { a: number; obj?: Obj }
+
+  const obj1: Obj = { a: 1 }
+  const obj2: Obj = { a: 1 }
+  obj1.obj = obj1
+  obj2.obj = obj1
+
+  expect(deepEqual(obj1, obj2)).toBe(true)
+})


### PR DESCRIPTION
### Summary

Updates the `deepEqual` check to return `true` immediately if the two values passed in are reference-equal. This should be a minor performance improvement, but the main driver for us is that we're getting a `Maximum call stack size exceeded` from this function in prod.

### Background

We hit a `Maximum call stack size exceeded` error when using this hook in production, with a stack trace in `deepEqual`:

```
RangeError: Maximum call stack size exceeded
    at M (../../../node_modules/.pnpm/react-hotkeys-hook@5.3.3_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/react-hotkeys-hook/packages/react-hotkeys-hook/dist/index.js:169:10)
    at <anonymous> (../../../node_modules/.pnpm/react-hotkeys-hook@5.3.3_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/react-hotkeys-hook/packages/react-hotkeys-hook/dist/index.js:170:154)
    at Array.reduce (<anonymous>)
    at M (../../../node_modules/.pnpm/react-hotkeys-hook@5.3.3_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/react-hotkeys-hook/packages/react-hotkeys-hook/dist/index.js:170:132)
    at <anonymous> (../../../node_modules/.pnpm/react-hotkeys-hook@5.3.3_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/react-hotkeys-hook/packages/react-hotkeys-hook/dist/index.js:170:154)
<snip>
```

The `options` we're passing in are pretty basic, the only non-primitive value is `document`:

```typescript
        {
            enabled: groupEnabled && enabled, // both booleans
            keydown: !!onKeyDown,
            keyup: !!onKeyUp,
            useKey: true,
            document: eventTargetDocument,
            preventDefault: true,
        }
```

The best guess I have is that some users have a browser extension that's patching `document` in a way that introduces a circular reference, though I haven't been able to confirm this.

### Alternatives

I suspect this was introduced in https://github.com/JohannesKlauss/react-hotkeys-hook/commit/fe419525fa1717dc9347fef4d9de7be65a99e437. Lodash's `isequal` does reference tracking to avoid this sort of error, though the function is a lot more complicated (unsurprisingly). Given that no-one else* has hit this issue in the ~4 years since that commit, feels like it would be overcooking things to go full reference tracking.

\* Similar error in https://github.com/JohannesKlauss/react-hotkeys-hook/issues/1373 but this won't fix that issue.